### PR TITLE
prevent CSRF exploits

### DIFF
--- a/jenkins/jenkins_files/files/var/lib/jenkins/config.xml
+++ b/jenkins/jenkins_files/files/var/lib/jenkins/config.xml
@@ -33,6 +33,9 @@
   <primaryView>All</primaryView>
   <slaveAgentPort>0</slaveAgentPort>
   <label></label>
+  <crumbIssuer class="hudson.security.csrf.DefaultCrumbIssuer">
+    <excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>
+  </crumbIssuer>
   <nodeProperties/>
   <globalNodeProperties/>
 </hudson>


### PR DESCRIPTION
Getting the necessary `crumb` is easy:

```
def get_crumb_data(jenkins_url):
    crumb_issuer_url = jenkins_url + '/crumbIssuer/api/python'
    data = urlopen(crumb_issuer_url).read().decode()
    crumb_issuer_response = literal_eval(data)
    crumb_request_field = crumb_issuer_response['crumbRequestField']
    crumb = crumb_issuer_response['crumb']
    return {crumb_request_field: crumb}
```

But currently `jenkinsapi` seems to be unable to pass it along with each request.
