### PR TITLE
add folder and publish configuratio to upload rosdistro_cache

### DIFF
--- a/jenkins/jenkins_files/files/var/lib/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml
+++ b/jenkins/jenkins_files/files/var/lib/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin_-Descriptor plugin="publish-over-ssh@1.12">
   <hostConfigurations>
     <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
@@ -13,6 +14,23 @@
         <keyPath>/var/lib/jenkins/.ssh/id_rsa</keyPath>
         <disableAllExec>true</disableAllExec>
       </commonConfig>
+      <timeout>300000</timeout>
+      <overrideKey>false</overrideKey>
+      <disableExec>false</disableExec>
+      <keyInfo>
+        <secretPassphrase></secretPassphrase>
+        <key></key>
+        <keyPath></keyPath>
+      </keyInfo>
+    </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
+    <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
+      <name>rosdistro_cache</name>
+      <hostname>repo</hostname>
+      <username>jenkins-slave</username>
+      <secretPassword></secretPassword>
+      <remoteRootDir>/var/repos/rosdistro_cache</remoteRootDir>
+      <port>22</port>
+      <commonConfig class="jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration" reference="../../jenkins.plugins.publish__over__ssh.BapSshHostConfiguration/commonConfig"/>
       <timeout>300000</timeout>
       <overrideKey>false</overrideKey>
       <disableExec>false</disableExec>

--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -19,6 +19,17 @@ file { '/home/jenkins-slave/.ssh':
     require => User['jenkins-slave'],
 }
 
+file { '/var/repos/rosdistro_cache':
+    ensure => 'directory',
+    mode   => '0755',
+    owner  => 'jenkins-slave',
+    group  => 'jenkins-slave',
+    require => [
+      User['jenkins-slave'],
+      File['/var/repos'],
+    ]
+}
+
 # TODO make this parameterized. This is a hack to get up and running on
 # the local development machines only!!!!!!
 # add ssh key


### PR DESCRIPTION
I have already applied both changes to the running EC2 farm:
- http://ec2-54-67-30-249.us-west-1.compute.amazonaws.com:8080/view/Manage/job/indigo_rosdistro_cache/
- http://ec2-54-67-51-1.us-west-1.compute.amazonaws.com/rosdistro_cache/
