### PR TITLE
make cleanup robust to lots of images or containers. Fixes #24. the comm...

### DIFF
--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -59,7 +59,7 @@ package { 'apparmor':
 
 # clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
 cron {'docker_cleanup_containers':
-  command => 'bash -c "docker rm `docker ps -aq`"',
+  command => 'bash -c "docker ps -aq | xargs -L1 docker rm "',
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,
@@ -68,7 +68,7 @@ cron {'docker_cleanup_containers':
   weekday => absent,
 }
 cron {'docker_cleanup_images':
-  command => 'bash -c "docker rmi `docker images --filter dangling=true --quiet`"',
+  command => 'bash -c "docker images --filter dangling=true --quiet | xargs -L1 docker rmi "',
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -138,7 +138,7 @@ else {
 
 # clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
 cron {'docker_cleanup_containers':
-  command => 'bash -c "docker rm `docker ps -aq`"',
+  command => 'bash -c "docker ps -aq | xargs -L1 docker rm "',
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,
@@ -147,7 +147,7 @@ cron {'docker_cleanup_containers':
   weekday => absent,
 }
 cron {'docker_cleanup_images':
-  command => 'bash -c "docker rmi `docker images --filter dangling=true --quiet`"',
+  command => 'bash -c "docker images --filter dangling=true --quiet | xargs -L1 docker rmi "',
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,


### PR DESCRIPTION
...and line was too long and was running over.


```
jenkins-slave@ip-172-31-15-92:/var/lib/docker$ bash -c "docker rmi `docker images --filter dangling=true --quiet`"\
> 
Error response from daemon: Conflict, cannot delete 4629868a3eef because the container fac20bd7db33 is using it, use -f to force
FATA[0002] Error: failed to remove one or more images   
bash: line 1: 6ba28401639d: command not found
bash: line 2: 892ce04d657a: command not found
bash: line 3: 2851a3e5d66a: command not found
bash: line 4: b216a8c72a02: command not found
bash: line 5: 77af5144058c: command not found
bash: line 6: b6ebaada2204: command not found
bash: line 7: fb48d8849257: command not found
bash: line 8: 52b831430c28: command not found
bash: line 9: e6e8f77fc8a1: command not found
bash: line 10: e114be3c7a76: command not found
...
```