### PR TITLE
move reprepro config and ssh authorized keys in to hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,22 @@ In particular you should change the following:
 On all three:
 * `jenkins::slave::ui_pass`
 * This is the passworkd for the slave to access the master
-* `user::admin::password_hash`
+ * `user::admin::password_hash`
 * On the master this should be the hashed password from above
-* The easiest way to create this is to setup a jenkins instance. Change the password, then copy the string out of config file on the jenkins server.
+ * The easiest way to create this is to setup a jenkins instance. Change the password, then copy the string out of config file on the jenkins server.
 * `autoreconfigure::branch`
 * If you are forking into a repo and using a different branch name, update the autoreconfigure command to point to the right branch.
+* `ssh_keys`
+* Configure as many license keys as you want for administrators to log in.
+
+::
+
+    ssh_keys:
+        'admin_access':
+            ensure: present
+            key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd
+            type: ssh-rsa
+            user: root
 
 On repo:
 * `jenkins-slave::authorized_keys`
@@ -95,7 +106,7 @@ On repo:
   * `jenkins-slave::reprepro_config`
    * Fill in the correct rules for upstream imports.
      It should be a hash/dict item with the filename as the key, ensure, and content as elements like below.
-     You can have as many elements as you want for different files. 
+     You can have as many elements as you want for different files.
 
 
     jenkins-slave::reprepro_config:

--- a/README.md
+++ b/README.md
@@ -92,25 +92,42 @@ On repo:
   * The GPG key with which to sign the repository.
   * `master::ip`
   * The IP address of the master instance.
+  * `jenkins-slave::reprepro_config`
+   * Fill in the correct rules for upstream imports.
+     It should be a hash/dict item with the filename as the key, ensure, and content as elements like below.
+     You can have as many elements as you want for different files. 
 
-  On the master:
-  * `jenkins::authorized_keys`
-  * This is the string contents for the authorized keys for the slaves to push into the repo. (It should match the `jenkins::private_ssh_key` on the master.
-    * `jenkins::private_ssh_key`
-    * The key which authorizes access to push content into the repository or to connect back to the master from a job.
-    * `master::ip`
-    * The IP address of the master instance.
-    * `repo::ip`
-    * The IP address of the repository instance.
 
-    On the slave:
-    * `master::ip`
-    * The IP address of the master instance.
-    * `repo::ip`
-    * The IP address of the repository instance.
-    * `jenkins::slave::num_executors`
-     * The number of executors to instantiate on each slave.
-       From current testing you can do one per available core, as long as at least 2GB of memory are available for each executor.
+    jenkins-slave::reprepro_config:
+        '/home/jenkins-slave/reprepro_config/empy_saucy.yaml':
+            ensure: 'present'
+            content: |
+                name: empy_saucy
+                method: http://packages.osrfoundation.org/gazebo/ubuntu
+                suites: [saucy]
+                component: main
+                architectures: [i386, amd64, source]
+                filter_formula: Package (% python3-empy)
+
+
+On the master:
+* `jenkins::authorized_keys`
+* This is the string contents for the authorized keys for the slaves to push into the repo. (It should match the `jenkins::private_ssh_key` on the master.
+  * `jenkins::private_ssh_key`
+  * The key which authorizes access to push content into the repository or to connect back to the master from a job.
+  * `master::ip`
+  * The IP address of the master instance.
+  * `repo::ip`
+  * The IP address of the repository instance.
+
+On the slave:
+* `master::ip`
+* The IP address of the master instance.
+* `repo::ip`
+* The IP address of the repository instance.
+* `jenkins::slave::num_executors`
+ * The number of executors to instantiate on each slave.
+   From current testing you can do one per available core, as long as at least 2GB of memory are available for each executor.
 
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -79,20 +79,27 @@ On all three:
 * This is the passworkd for the slave to access the master
  * `user::admin::password_hash`
 * On the master this should be the hashed password from above
- * The easiest way to create this is to setup a jenkins instance. Change the password, then copy the string out of config file on the jenkins server.
+ * The easiest way to create this is to setup a jenkins instance.
+   Change the password, then copy the string out of config file on the jenkins server.
 * `autoreconfigure::branch`
 * If you are forking into a repo and using a different branch name, update the autoreconfigure command to point to the right branch.
 * `ssh_keys`
-* Configure as many license keys as you want for administrators to log in.
+ * Configure as many license keys as you want for administrators to log in.
+ * Make sure there is at least one key for jenkins-slave on the repo matching the `jenkins::private_key` provisioned on the master.
 
 ::
 
     ssh_keys:
-        'admin_access':
+        'admin@foobar':
             ensure: present
             key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd
             type: ssh-rsa
             user: root
+        'upload_access@buildfarm':
+            ensure: present
+            key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2NOaRsdZqqTrCwNR77AQIqwAPYkDfiL1Ou7Pi/qaW9S7UU0Y1KAQ6kWhgJc9RtOhbZKGHbFTqSLT4235TkmPvlZbV2bK8ZViBmqQ3r8vDMhC/+p9Ec9SP8sjv6JcIEWOy5zXPnB3OnHHWXmvZP47rjJY0l76F71fZt3vlvyjz7IrikULmuKcyrE+zulmbSTtfGZhxQRPxZDO/RiOemCPsYo5u/rUMjWH+CkEI0swQlM6QIvjWdfYtNwQT9yo53MXFy5jodhW4YOOncKE4RMOI9Lmu6jE0GmdmSEv486R4ot6iWanx2hk/46zlmX1kSKGWObRdH57H/xIAxvw+PiTd
+            type: ssh-rsa
+            user: jenkins-slave
 
 On repo:
 * `jenkins-slave::authorized_keys`
@@ -123,7 +130,8 @@ On repo:
 
 On the master:
 * `jenkins::authorized_keys`
-* This is the string contents for the authorized keys for the slaves to push into the repo. (It should match the `jenkins::private_ssh_key` on the master.
+* This is the string contents for the authorized keys for the slaves to push into the repo.
+  It should match the `jenkins::private_ssh_key` on the master.
   * `jenkins::private_ssh_key`
   * The key which authorizes access to push content into the repository or to connect back to the master from a job.
   * `master::ip`

--- a/doc/DevelopmentTesting.md
+++ b/doc/DevelopmentTesting.md
@@ -50,3 +50,11 @@ fig up
 ### Accessing the local images
 
 This will expose the master as http://localhost:8080 and the repo at http://localhost:8081
+
+
+## Kicking off jobs inside docker
+
+Once you have the farm up you will need to configure it using [ros_buildfarm](https://github.com/ros-infrastructure/ros_buildfarm).
+
+You can get access to the docker machines by ip.
+But for convenience there's a helper docker image you can use to configure the buildfarm inside docker, [buildfarm_inprogress_helpers]](http://github.com/tfoote/buildfarm_inprogress_helpers)

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -38,20 +38,19 @@ class { 'jenkins::slave':
   slave_mode => 'exclusive',
   slave_name => 'slave_on_master',
   slave_user => 'jenkins-slave',
-  manage_slave_user => '1',
+  manage_slave_user => false,
   executors => '1',
   install_java => false,
+  require => User['jenkins-slave'],
 }
 
-exec {"jenkins-slave docker membership":
-  path    => '/usr/sbin:/usr/bin:/sbin:/bin',
-  unless => "grep -q 'docker\\S*jenkins-slave' /etc/group",
-  command => "usermod -aG docker jenkins-slave",
-  require => [User['jenkins-slave'],
-              Package['docker'],
-             ],
-  notify => Service['jenkins-slave'],
+user{'jenkins-slave':
+  ensure => present,
+  managehome => true,
+  groups => ['docker'],
+  require => Package['lxc-docker']
 }
+
 
 $slave_buildfarm_config_dir = ['/home/jenkins-slave/.buildfarm']
 file { $slave_buildfarm_config_dir:

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -436,13 +436,18 @@ file { '/var/lib/jenkins/.ssh/id_rsa':
     content => hiera('jenkins::private_ssh_key'),
     require => File['/var/lib/jenkins/.ssh'],
 }
-file { '/var/lib/jenkins/.ssh/id_rsa.pub':
-    mode => '0600',
-    owner => 'jenkins',
-    group => 'jenkins',
-    content => hiera('jenkins::authorized_keys'),
-    require => File['/var/lib/jenkins/.ssh'],
+
+# Setup generic ssh_keys
+if hiera('ssh_keys', false){
+  $defaults = {
+    'ensure' => 'present',
+  }
+  create_resources(ssh_authorized_key, hiera('ssh_keys'), $defaults)
 }
+else{
+  notice("No ssh_authorized_keys defined. There should probably be at least one.")
+}
+
 
 # Reference above credientials
 file { '/var/lib/jenkins/credentials.xml':

--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -129,15 +129,6 @@ package { 'python3-psutil':
   ensure => 'installed',
 }
 
-vcsrepo { "/home/jenkins-slave/reprepro-updater":
-  ensure   => latest,
-  provider => git,
-  source   => 'https://github.com/ros-infrastructure/reprepro-updater.git',
-  revision => 'refactor',
-  user     => 'jenkins-slave',
-  require => User['jenkins-slave'],
-}
-
 $repo_dirs = ['/var/repos',
               '/var/repos/ubuntu',]
 
@@ -298,7 +289,6 @@ exec {"init_main_repo":
                  ]
 }
 
-
 # clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
 cron {'docker_cleanup_images':
   command => 'bash -c "python3 -u /home/jenkins-slave/cleanup_docker_images.py"',
@@ -309,4 +299,29 @@ cron {'docker_cleanup_images':
   minute  => 15,
   weekday => absent,
   require => User['jenkins-slave'],
+}
+
+# needed for boostrapping the repo
+vcsrepo { "/home/jenkins-slave/reprepro-updater":
+  ensure   => latest,
+  provider => git,
+  source   => 'https://github.com/ros-infrastructure/reprepro-updater.git',
+  revision => 'refactor',
+  user     => 'jenkins-slave',
+  require => User['jenkins-slave'],
+}
+
+
+# Create directory for reprepro_config
+file { '/home/jenkins-slave/reprepro_config':
+  ensure => 'directory',
+  owner  => 'jenkins-slave',
+  group  => 'jenkins-slave',
+  mode   => '700',
+  require => User['jenkins-slave'],
+}
+
+# Pull reprepro updater
+if hiera('jenkins-slave::reprepro_config', false){
+  create_resources(file, hiera('jenkins-slave::reprepro_config'))
 }

--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -23,26 +23,6 @@ include '::ntp'
 class {'docker':
 }
 
-# clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
-cron {'docker_cleanup_containers':
-  command => 'bash -c "docker ps -aq | xargs -L1 docker rm "',
-  user    => 'jenkins-slave',
-  month   => absent,
-  monthday => absent,
-  hour    => '*/6',
-  minute  => absent,
-  weekday => absent,
-}
-cron {'docker_cleanup_images':
-  command => 'bash -c "docker images --filter dangling=true --quiet | xargs -L1 docker rmi "',
-  user    => 'jenkins-slave',
-  month   => absent,
-  monthday => absent,
-  hour    => '*/6',
-  minute  => absent,
-  weekday => absent,
-}
-
 # Find the other instances
 if hiera('master::ip', false) {
   host {'master':

--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -10,17 +10,9 @@ class { 'jenkins::slave':
 user{'jenkins-slave':
   ensure => present,
   managehome => true,
+  groups => ['docker'],
+  require => Package['lxc-docker']
 }
-
-exec {"jenkins-slave docker membership":
-  path    => '/usr/sbin:/usr/bin:/sbin:/bin',
-  unless => "grep -q 'docker\\S*jenkins-slave' /etc/group",
-  command => "usermod -aG docker jenkins-slave",
-  require => [User['jenkins-slave'],
-              Package['lxc-docker'],
-             ],
-}
-
 
 
 # setup ntp with defaults

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -37,20 +37,18 @@ class { 'jenkins::slave':
   labels => 'buildslave',
   slave_mode => 'exclusive',
   slave_user => 'jenkins-slave',
-  manage_slave_user => '1',
+  manage_slave_user => false,
   executors => hiera('jenkins::slave::num_executors', 1),
+  require => User['jenkins-slave'],
 }
 
-
-exec {"jenkins-slave docker membership":
-  path    => '/usr/sbin:/usr/bin:/sbin:/bin',
-  unless => "grep -q 'docker\\S*jenkins-slave' /etc/group",
-  command => "usermod -aG docker jenkins-slave",
-  require => [User['jenkins-slave'],
-              Package['docker'],
-             ],
-  notify => Service['jenkins-slave'],
+user{'jenkins-slave':
+  ensure => present,
+  managehome => true,
+  groups => ['docker'],
+  require => Package['lxc-docker']
 }
+
 
 ## required by jobs to generate Dockerfiles
 package { 'python3-empy':

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -22,6 +22,17 @@ else {
   }
 }
 
+# Setup generic ssh_keys
+if hiera('ssh_keys', false){
+  $defaults = {
+    'ensure' => 'present',
+  }
+  create_resources(ssh_authorized_key, hiera('ssh_keys'), $defaults)
+}
+else{
+  notice("No ssh_keys defined. You should probably have at least one.")
+}
+
 class { 'jenkins::slave':
   labels => 'buildslave',
   slave_mode => 'exclusive',


### PR DESCRIPTION
Fixes #22 

There also are some small cleanup commits. This needs a corresponding addition to the buildfarm_deployment_config hiera configs. 

- Add reprepro_config: https://github.com/ros-infrastructure/buildfarm_deployment_config/commit/fd8cd8332c7e88021d36859b6fca13926e9ce32a
- Move ssh key for jenkins-slave: https://github.com/ros-infrastructure/buildfarm_deployment_config/commit/f453fb39790efaf7ea97e8eb1e768334b28de69c