### PR TITLE
do not remove dangling images first

### DIFF
--- a/master/jenkins_files/files/home/jenkins-slave/cleanup_docker_images.py
+++ b/master/jenkins_files/files/home/jenkins-slave/cleanup_docker_images.py
@@ -36,9 +36,6 @@ def get_free_disk_percentage(path='/'):
 def get_image_list():
     cmd = "docker images -q".split()
     images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    cmd = "docker images -q --filter dangling=true".split()
-    dangling_images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    images.extend(dangling_images)
     return reversed(images)
 
 

--- a/repo/repo_files/files/home/jenkins-slave/cleanup_docker_images.py
+++ b/repo/repo_files/files/home/jenkins-slave/cleanup_docker_images.py
@@ -36,9 +36,6 @@ def get_free_disk_percentage(path='/'):
 def get_image_list():
     cmd = "docker images -q".split()
     images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    cmd = "docker images -q --filter dangling=true".split()
-    dangling_images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    images.extend(dangling_images)
     return reversed(images)
 
 

--- a/slave/slave_files/files/home/jenkins-slave/cleanup_docker_images.py
+++ b/slave/slave_files/files/home/jenkins-slave/cleanup_docker_images.py
@@ -36,9 +36,6 @@ def get_free_disk_percentage(path='/'):
 def get_image_list():
     cmd = "docker images -q".split()
     images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    cmd = "docker images -q --filter dangling=true".split()
-    dangling_images = subprocess.check_output(cmd).decode('utf8').splitlines()
-    images.extend(dangling_images)
     return reversed(images)
 
 


### PR DESCRIPTION
Adding the dangling images to the end of the images list will result in them being removed at first. That breaks ongoing docker builds, e.g. http://54.183.26.131:8080/job/Ibin_uT64__force_rotate_recovery__ubuntu_trusty_amd64__binary/3/console

Without them being explicitly listed they will still be removed when the get older.

@tfoote Please review and merge.