### PR TITLE
calling out concat version

### DIFF
--- a/master/Puppetfile
+++ b/master/Puppetfile
@@ -2,6 +2,7 @@ forge "https://forgeapi.puppetlabs.com"
 
 mod 'example42-iptables'
 mod 'garethr-docker'
+mod 'puppetlabs-concat', '1.2.3'
 mod 'puppetlabs-ntp'
 mod 'rtyler/jenkins'
 mod 'tracywebtech-pip', '1.3.2'


### PR DESCRIPTION
Fixes #66

There was at some point a concat 2.0.1 pushed accidentally. It was in the repos and librarian was trying to pull it down automatically despite it having been deleted. 

This forces the version. 