### PR TITLE
Docker cleanup script was not installed on master

### DIFF
--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -482,6 +482,15 @@ else {
   }
 }
 
+# script to clean up docker images from oldest
+file { '/home/jenkins-slave/cleanup_docker_images.py':
+  mode => '0774',
+  owner => 'jenkins-slave',
+  group => 'jenkins-slave',
+  source => 'puppet:///modules/jenkins_files/home/jenkins-slave/cleanup_docker_images.py',
+  require => User['jenkins-slave'],
+}
+
 # clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
 cron {'docker_cleanup_images':
   command => 'bash -c "python3 -u /home/jenkins-slave/cleanup_docker_images.py"',

--- a/repo/repo_files/manifests/init.pp
+++ b/repo/repo_files/manifests/init.pp
@@ -1,3 +1,3 @@
-class slave_files {
+class repo_files {
 
 }


### PR DESCRIPTION
Our master crashed because of a full disk, so I just found out that the cleanup script was missing
Shouldn't the cron resources depend on the corresponding file resources?