### PR TITLE
Added support for git clone over SSH.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On all three:
 * `ssh_keys`
  * Configure as many public ssh-keys as you want for administrators to log in.
    It's recommended at least one for root.
- * On the repo machine make sure there is at least one key for the jenkins-slave user matching the ssh private key 
+ * On the repo machine make sure there is at least one key for the jenkins-slave user matching the ssh private key
   `jenkins::private_key` provisioned on the master.
 
 ::
@@ -134,7 +134,7 @@ On the master:
   * The ssh private key  will be provisioned as an ssh-credential available via the ssh-agent inside a jenkins jobs.
     This is necessary for access to push content onto the repo machine.
     It can also be used to access other machines from within the job execution environment.
-    This will require deploying the matching public key to the other machines appropriately. 
+    This will require deploying the matching public key to the other machines appropriately.
     **Note: This value should be kept secret!**
   * `master::ip`
   * The IP address of the master instance.
@@ -147,8 +147,18 @@ On the master:
   * A UUID for the credentials in thef format `1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5`
   * `credentials::jenkins-slave::passphrase`
   * The hashed passphrase for the key. The UI puts this has in if there's now passphrase `4lRsx/NwfEndwUlcWOOnYg== `
-   * If you would like to modify these values from the default it will likely be easiest to boot an instance. Change the credentials via the UI, then grab the values out of the config file. 
-  
+   * If you would like to modify these values from the default it will likely be easiest to boot an instance. Change the credentials via the UI, then grab the values out of the config file.
+
+  * If you would like to be able to clone source and release repositories over git+ssh, add the `git-fetch-ssh` credential by setting the following optional parameters:
+    * `credentials::git-fetch-ssh::username`
+    * The name of the credentials
+    * `credentials::git-fetch-ssh::id`
+    * A UUID for the credentials in the format `1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5`
+    * `credentials::git-fetch-ssh::passphrase`
+    * The hashed passphrase for the key. The UI puts this hash in if there's no passphrase: `4lRsx/NwfEndwUlcWOOnYg== `
+    * `credentials::git-fetch-ssh::private_key`
+    * An SSH private key that has access to the source and release repositories that the buildfarm will use.
+
 
 On the slave:
 * `master::ip`
@@ -158,7 +168,15 @@ On the slave:
 * `jenkins::slave::num_executors`
  * The number of executors to instantiate on each slave.
    From current testing you can do one per available core, as long as at least 2GB of memory are available for each executor.
-
+* `ssh_host_keys`
+* Optional. If you would like to clone source and release repositories over git+ssh, set the host keys for the servers that will be used in the `ssh_host_keys` parameter. This parameter is a dictionary mapping server names to host keys. Host keys can be discovered with the `ssh-keyscan -H <hostname>` command.
+````
+ssh_host_keys:
+    'github.com': |
+        |1|/F/a+D+AA/y+qf7+IMSwXbvfFZo=|Pygbd2OeNdWzbgAyZK/kwEet9u0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+    'bitbucket.org': |
+        |1|VoTP5i1zOk28A+ELJ0XpcMdpiBc=|Y61MET377AK92/9wJzCZhQMoGmw= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+````
 
 ## Deployment
 

--- a/master/jenkins_files/templates/credentials.xml.erb
+++ b/master/jenkins_files/templates/credentials.xml.erb
@@ -8,12 +8,25 @@
       <java.util.concurrent.CopyOnWriteArrayList>
         <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey plugin="ssh-credentials@1.10">
           <scope>GLOBAL</scope>
-          <id><%= scope.function_hiera(["credentials::jenkins-slave::id"]) %></id>
+          <id><%= @credentials["jenkins-slave"]["id"] %></id>
           <description></description>
-          <username><%= scope.function_hiera(["credentials::jenkins-slave::username"]) %></username>
-          <passphrase><%= scope.function_hiera(["credentials::jenkins-slave::passphrase"]) %></passphrase>
+          <username><%= @credentials["jenkins-slave"]["username"] %></username>
+          <passphrase><%= @credentials["jenkins-slave"]["passphrase"] %></passphrase>
           <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$UsersPrivateKeySource"/>
         </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+<% if ! @credentials["git-fetch-ssh"]["username"].empty? %>
+        <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey plugin="ssh-credentials@1.10">
+          <scope>GLOBAL</scope>
+          <id><%= @credentials["git-fetch-ssh"]["id"] %></id>
+          <description></description>
+          <username><%= @credentials["git-fetch-ssh"]["username"] %></username>
+          <passphrase><%= @credentials["git-fetch-ssh"]["passphase"] %></passphrase>
+          <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$DirectEntryPrivateKeySource">
+            <privateKey><%= @credentials["git-fetch-ssh"]["private_key"] %>
+            </privateKey>
+          </privateKeySource>
+        </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
+<% end %>
       </java.util.concurrent.CopyOnWriteArrayList>
     </entry>
   </domainCredentialsMap>

--- a/master/jenkins_files/templates/credentials.xml.erb
+++ b/master/jenkins_files/templates/credentials.xml.erb
@@ -8,21 +8,21 @@
       <java.util.concurrent.CopyOnWriteArrayList>
         <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey plugin="ssh-credentials@1.10">
           <scope>GLOBAL</scope>
-          <id><%= @credentials["jenkins-slave"]["id"] %></id>
+          <id><%= scope.function_hiera(["credentials::jenkins-slave::id"]) %></id>
           <description></description>
-          <username><%= @credentials["jenkins-slave"]["username"] %></username>
-          <passphrase><%= @credentials["jenkins-slave"]["passphrase"] %></passphrase>
+          <username><%= scope.function_hiera(["credentials::jenkins-slave::username"]) %></username>
+          <passphrase><%= scope.function_hiera(["credentials::jenkins-slave::passphrase"]) %></passphrase>
           <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$UsersPrivateKeySource"/>
         </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>
-<% if ! @credentials["git-fetch-ssh"]["username"].empty? %>
+<% if ! scope.function_hiera(["credentials::git-fetch-ssh::username", ""]).empty? %>
         <com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey plugin="ssh-credentials@1.10">
           <scope>GLOBAL</scope>
-          <id><%= @credentials["git-fetch-ssh"]["id"] %></id>
+          <id><%= scope.function_hiera(["credentials::git-fetch-ssh::id"]) %></id>
           <description></description>
-          <username><%= @credentials["git-fetch-ssh"]["username"] %></username>
-          <passphrase><%= @credentials["git-fetch-ssh"]["passphase"] %></passphrase>
+          <username><%= scope.function_hiera(["credentials::git-fetch-ssh::username"]) %></username>
+          <passphrase><%= scope.function_hiera(["credentials::git-fetch-ssh::passphrase"]) %></passphrase>
           <privateKeySource class="com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey$DirectEntryPrivateKeySource">
-            <privateKey><%= @credentials["git-fetch-ssh"]["private_key"] %>
+            <privateKey><%= scope.function_hiera(["credentials::git-fetch-ssh::private_key"]) %>
             </privateKey>
           </privateKeySource>
         </com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey>

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -454,19 +454,6 @@ else{
 
 
 # Reference above credientials
-$credentials = {
-  'jenkins-slave' => {
-    'username' => hiera('credentials::jenkins-slave::username'),
-    'passphrase' => hiera('credentials::jenkins-slave::passphrase'),
-    'id' => hiera('credentials::jenkins-slave::id'),
-  },
-  'git-fetch-ssh' => {
-    'username' => hiera('credentials::git-fetch-ssh::username', ''),
-    'passphrase' => hiera('credentials::git-fetch-ssh::passphrase', ''),
-    'id' => hiera('credentials::git-fetch-ssh::id', ''),
-    'private_key' => hiera('credentials::git-fetch-ssh::private_key', '')
-  },
-}
 file { '/var/lib/jenkins/credentials.xml':
     mode => '0600',
     owner => 'jenkins',

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -464,6 +464,7 @@ $credentials = {
     'username' => hiera('credentials::git-fetch-ssh::username', ''),
     'passphrase' => hiera('credentials::git-fetch-ssh::passphrase', ''),
     'id' => hiera('credentials::git-fetch-ssh::id', ''),
+    'private_key' => hiera('credentials::git-fetch-ssh::private_key', '')
   },
 }
 file { '/var/lib/jenkins/credentials.xml':

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -284,6 +284,10 @@ jenkins::plugin {
 }
 
 jenkins::plugin {
+  'workflow-step-api': ;
+}
+
+jenkins::plugin {
   'writable-filesystem-monitor': ;
 }
 

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -454,6 +454,18 @@ else{
 
 
 # Reference above credientials
+$credentials = {
+  'jenkins-slave' => {
+    'username' => hiera('credentials::jenkins-slave::username'),
+    'passphrase' => hiera('credentials::jenkins-slave::passphrase'),
+    'id' => hiera('credentials::jenkins-slave::id'),
+  },
+  'git-fetch-ssh' => {
+    'username' => hiera('credentials::git-fetch-ssh::username', ''),
+    'passphrase' => hiera('credentials::git-fetch-ssh::passphrase', ''),
+    'id' => hiera('credentials::git-fetch-ssh::id', ''),
+  },
+}
 file { '/var/lib/jenkins/credentials.xml':
     mode => '0600',
     owner => 'jenkins',

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -50,7 +50,6 @@ file { '/home/jenkins-slave/.ssh/' :
   require => User['jenkins-slave'],
 }
 
-$host_keys = hiera('ssh_host_keys', [])
 file { '/home/jenkins-slave/.ssh/known_hosts':
   ensure => 'present',
   mode => '0644',

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -41,6 +41,25 @@ else{
   notice("No ssh_keys defined. You should probably have at least one.")
 }
 
+# Setup SSH known hosts
+file { '/home/jenkins-slave/.ssh/' :
+  ensure => 'directory',
+  mode   => '644',
+  owner  => 'jenkins-slave',
+  group  => 'jenkins-slave',
+  require => User['jenkins-slave'],
+}
+
+$host_keys = hiera('ssh_host_keys', [])
+file { '/home/jenkins-slave/.ssh/known_hosts':
+  ensure => 'present',
+  mode => '0644',
+  owner => 'jenkins-slave',
+  group => 'jenkins-slave',
+  content => template('slave_files/known_hosts.erb'),
+  require => User['jenkins-slave'],
+}
+
 class { 'jenkins::slave':
   labels => 'buildslave',
   slave_mode => 'exclusive',

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -57,7 +57,7 @@ file { '/home/jenkins-slave/.ssh/known_hosts':
   owner => 'jenkins-slave',
   group => 'jenkins-slave',
   content => template('slave_files/known_hosts.erb'),
-  require => User['jenkins-slave'],
+  require => File['/home/jenkins-slave/.ssh/'],
 }
 
 class { 'jenkins::slave':

--- a/slave/slave_files/templates/known_hosts.erb
+++ b/slave/slave_files/templates/known_hosts.erb
@@ -1,0 +1,3 @@
+<% @host_keys.each do | hostname, host_key| %>
+<%= host_key %>
+<% end %>

--- a/slave/slave_files/templates/known_hosts.erb
+++ b/slave/slave_files/templates/known_hosts.erb
@@ -1,3 +1,3 @@
-<% @host_keys.each do | hostname, host_key| %>
+<% scope.function_hiera(["ssh_host_keys", []]).each do | hostname, host_key| %>
 <%= host_key %>
 <% end %>


### PR DESCRIPTION
This is part of a proposed fix for ros_buildfarm [issue #91](https://github.com/ros-infrastructure/ros_buildfarm/issues/91), adding support for cloning source and release repositories over git+ssh.

This provides a credential in Jenkins with an SSH private key as well as setting up in the SSH known hosts on the slave so jobs can git clone without any user intervention.

The parameters added in this PR can be omitted entirely for users who do not need this functionality.