### PR TITLE
Upgrade to docker 1.7.1

### DIFF
--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -109,7 +109,7 @@ include '::ntp'
 ### install latest docker
 
 class {'docker':
-  version => '1.6.1',
+  version => '1.7.1',
 }
 
 package { 'python3-pip':


### PR DESCRIPTION
This is the newest supported by the currently released garethr-docker.

The newer versions are supported in master, but have not been rolled out to puppet-forge yet:

https://github.com/garethr/garethr-docker/pull/311

Once garethr-docker gets released, we can push forward to 1.8.*