### PR TITLE
Upgrading to docker 1.9.1

### DIFF
--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -26,7 +26,7 @@ if hiera('classes', false) {
 ### install latest docker
 
 class {'docker':
-  version => '1.7.1',
+  version => '1.9.1',
 }
 
 # Find the other instances

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -109,7 +109,7 @@ include '::ntp'
 ### install latest docker
 
 class {'docker':
-  version => '1.7.1',
+  version => '1.9.1',
 }
 
 package { 'python3-pip':


### PR DESCRIPTION
Fixes #78 

The farm has been running since yesterday evening with 1.9.1 manually forced on both the repo and slave. We went through a full rebuild cycle overnight as well as I manually triggered several builds both doc and release jobs all of which passed.  And reviewing the overnight builds I do not see any noticable regressions. 