### PR TITLE
fix default syntax

### DIFF
--- a/master/jenkins_files/templates/etc_default_jenkins.erb
+++ b/master/jenkins_files/templates/etc_default_jenkins.erb
@@ -7,7 +7,7 @@ NAME=jenkins
 JAVA=/usr/bin/java
 
 # arguments to pass to java
-JAVA_ARGS="-Djava.awt.headless=true -Dhudson.diyChunking=false <%= scope.function_hiera(["jenkins_java_args"], '') %>"  # Allow graphs etc. to work even when an X server is present
+JAVA_ARGS="-Djava.awt.headless=true -Dhudson.diyChunking=false <%= scope.function_hiera(["jenkins_java_args", '']) %>"  # Allow graphs etc. to work even when an X server is present
 #JAVA_ARGS="-Xmx256m"
 #JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
 


### PR DESCRIPTION
The default arguments come inside the list not as a separate argument