### PR TITLE
force docker module version to 5.0.0 our syntax does not work with 4.x

### DIFF
--- a/master/Puppetfile
+++ b/master/Puppetfile
@@ -1,7 +1,7 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod 'example42-iptables'
-mod 'garethr-docker'
+mod 'garethr-docker', '5.0.0'
 mod 'puppetlabs-apache', '1.1.1'
 mod 'puppetlabs-concat', '1.2.3'
 mod 'puppetlabs-ntp'

--- a/repo/Puppetfile
+++ b/repo/Puppetfile
@@ -1,7 +1,7 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod 'example42-iptables'
-mod 'garethr-docker'
+mod 'garethr-docker', '5.0.0'
 mod 'puppetlabs-concat', '1.2.3'
 mod 'puppetlabs-ntp'
 mod 'rtyler/jenkins'

--- a/slave/Puppetfile
+++ b/slave/Puppetfile
@@ -1,6 +1,6 @@
 forge "https://forgeapi.puppetlabs.com"
 
-mod 'garethr-docker'
+mod 'garethr-docker', '5.0.0'
 mod 'krakatoa-upstart', :path => '../krakatoa-upstart-0.0.1'
 mod 'puppetlabs-concat', '1.2.3'
 mod 'puppetlabs-ntp'


### PR DESCRIPTION
This is only an issue with older slaves which have previously installed 4.x 

New installations will already have 5.0.0. And this will protect us against future api changes. 