### PR TITLE
cleanup scripts are much faster now, we can run them hourly.

### DIFF
--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -587,7 +587,7 @@ cron {'docker_cleanup_images':
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,
-  hour    => '*/2',
+  hour    => '*',
   minute  => 15,
   weekday => absent,
   require => User['jenkins-slave'],

--- a/repo/manifests/site.pp
+++ b/repo/manifests/site.pp
@@ -307,7 +307,7 @@ cron {'docker_cleanup_images':
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,
-  hour    => '*/2',
+  hour    => '*',
   minute  => 15,
   weekday => absent,
   require => User['jenkins-slave'],

--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -233,7 +233,7 @@ cron {'docker_cleanup_images':
   user    => 'jenkins-slave',
   month   => absent,
   monthday => absent,
-  hour    => '*/2',
+  hour    => '*',
   minute  => 15,
   weekday => absent,
   require => User['jenkins-slave'],


### PR DESCRIPTION
This means that under heavy load they are less likely to go offline for periods waiting for disk space cleanup.