### PR TITLE
Cleanup disk space more often

### DIFF
--- a/slave/manifests/site.pp
+++ b/slave/manifests/site.pp
@@ -234,7 +234,7 @@ cron {'docker_cleanup_images':
   month   => absent,
   monthday => absent,
   hour    => '*',
-  minute  => 15,
+  minute  => */15,
   weekday => absent,
   require => User['jenkins-slave'],
 }


### PR DESCRIPTION
The hourly cleanup currently takes less than a minute. We can afford to cleanup much more often now. And this should keep us from running out of space