### PR TITLE
Add a config to turn on caching for mercurial to avoid rebuilding to …

### DIFF
--- a/master/jenkins_files/files/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml
+++ b/master/jenkins_files/files/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson.plugins.mercurial.MercurialInstallation_-DescriptorImpl plugin="mercurial@1.54">
+  <installations>
+    <hudson.plugins.mercurial.MercurialInstallation>
+      <name>Default</name>
+      <home>/usr</home>
+      <properties/>
+      <executable>INSTALLATION/bin/hg</executable>
+      <debug>false</debug>
+      <useCaches>true</useCaches>
+      <useSharing>true</useSharing>
+    </hudson.plugins.mercurial.MercurialInstallation>
+  </installations>
+</hudson.plugins.mercurial.MercurialInstallation_-DescriptorImpl>

--- a/master/manifests/site.pp
+++ b/master/manifests/site.pp
@@ -423,6 +423,19 @@ file { '/var/lib/jenkins/config.xml':
   notify => Service['jenkins'],
 }
 
+# Use default mercurial, but enable caching.
+# Otherwise if the workspace is lost mercurial will trigger a job
+# whenever it tries to poll.
+file { '/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml':
+  ensure => 'present',
+  mode => '0640',
+  owner => jenkins,
+  group => jenkins,
+  source => 'puppet:///modules/jenkins_files/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml',
+  require => Package['jenkins'],
+  notify => Service['jenkins'],
+}
+
 file { '/var/lib/jenkins/nodeMonitors.xml':
   ensure => 'present',
   mode => '0640',


### PR DESCRIPTION
…generate workspaces with the last cache.

Otherwise when the workspace goes away it triggers every time jenkins is polling.

Turning on caching is the solution: https://issues.jenkins-ci.org/browse/JENKINS-12404