### PR TITLE
Enable parallel jobs on the master node

### DIFF
--- a/master/jenkins_files/files/var/lib/jenkins/config.xml
+++ b/master/jenkins_files/files/var/lib/jenkins/config.xml
@@ -2,7 +2,7 @@
 <hudson>
   <disabledAdministrativeMonitors/>
   <version>1.0</version>
-  <numExecutors>1</numExecutors>
+  <numExecutors>4</numExecutors>
   <mode>EXCLUSIVE</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy"/>


### PR DESCRIPTION
The jobs tied to the master node do not require running serially. 

They are not long running or resource intensive, but there are a bunch of them and allowing them to run in parallel will allow the farm to be more responsive. 

Especially wrt status page updates (https://github.com/ros-infrastructure/ros_buildfarm/pull/327) and the rosdistro cache (right now the 3 have to run in series) 

This also helps stave off the approaching starvation on this machine. The rosdistro caches durations are over 30 seconds and sometime approach 1 minute, and running every 5 minutes means they are using almost half the time available. Running in parallel, there is not a risk of them approaching full dutycycle since they can run in parallel. 

I've manually updated the buildfarm and all jobs appear to be operating normally. 
