### PR TITLE
Pin ntp to 4.2.0 and jenkins to 1.6.1

### DIFF
--- a/master/Puppetfile
+++ b/master/Puppetfile
@@ -4,8 +4,8 @@ mod 'example42-iptables'
 mod 'garethr-docker', '5.0.0'
 mod 'puppetlabs-apache', '1.1.1'
 mod 'puppetlabs-concat', '1.2.3'
-mod 'puppetlabs-ntp'
-mod 'rtyler/jenkins'
+mod 'puppetlabs-ntp', '4.2.0'
+mod 'rtyler/jenkins', '1.6.1'
 mod 'tracywebtech-pip', '1.3.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"

--- a/repo/Puppetfile
+++ b/repo/Puppetfile
@@ -3,8 +3,8 @@ forge "https://forgeapi.puppetlabs.com"
 mod 'example42-iptables'
 mod 'garethr-docker', '5.0.0'
 mod 'puppetlabs-concat', '1.2.3'
-mod 'puppetlabs-ntp'
-mod 'rtyler/jenkins'
+mod 'puppetlabs-ntp', '4.2.0'
+mod 'rtyler/jenkins', '1.6.1'
 mod 'tracywebtech-pip', '1.3.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"

--- a/slave/Puppetfile
+++ b/slave/Puppetfile
@@ -4,7 +4,7 @@ mod 'garethr-docker', '5.0.0'
 mod 'krakatoa-upstart', :path => '../krakatoa-upstart-0.0.1'
 mod 'puppetlabs-concat', '1.2.3'
 mod 'puppetlabs-ntp', '4.2.0'
-mod 'rtyler/jenkins'
+mod 'rtyler/jenkins', '1.6.1'
 mod 'tracywebtech-pip', '1.3.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"


### PR DESCRIPTION
This will pin the versions of the rtyler/jenkins and puppetlabs-ntp
dependencies in all Puppetfiles, which is necessary in order to
provision new hosts from scratch.

Resolves #141