### PR TITLE
Add supported server distro to Provisioning steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ At the end of this process you will have a Jenkins master, a package repository,
 
 ## Provisioning
 
+The ROS buldfarm deployment is currently based on Ubuntu 14.04 Trusty.
 The following EC2 instance types are recommended when deploying to Amazon EC2.
 They are intended as a guideline for choosing the appropriate parameters when deploying to other platforms.
 


### PR DESCRIPTION
This adds the fact that the buildfarm puppet scripts currently target Ubuntu 14.04 in an attempt to resolve #151. When the xenialize branch lands we'll need to be sure to update this line.