### PR TITLE
improve regex to detect and extract CMake warnings

### DIFF
--- a/master/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
+++ b/master/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
@@ -3,16 +3,20 @@
   <groovyParsers>
     <hudson.plugins.warnings.GroovyParser>
       <name>CMake</name>
-      <regexp>^CMake (Deprecation Warning|Warning|Warning \(dev\)|Error) at (.+):(\d+) \((.+)\):\n(  .+\n)?(.+\n(  .+\n)*)?</regexp>
+      <regexp>^CMake (Deprecation Warning|Warning|Warning \(dev\)|Error) at (.+):(\d+)( \((.+)\))?:\n(  .+\n)?(.+\n(  .+\n)*)?</regexp>
       <script>import hudson.plugins.analysis.util.model.Priority
 import hudson.plugins.warnings.parser.Warning
 
 String messageType = matcher.group(1)
 String fileName = matcher.group(2)
 String lineNumber = matcher.group(3)
-String scope = matcher.group(4)
-String cmakeMessage = matcher.group(5)
-String callStack = matcher.group(6)
+String scope = matcher.group(5)
+String cmakeMessage = matcher.group(6)
+String callStack = matcher.group(7)
+
+if (!scope) {
+    scope = &quot;global&quot;
+}
 
 String message = &quot;&quot;
 if (cmakeMessage) {


### PR DESCRIPTION
The previous regex only matched messages like this:

```
CMake Warning at /home/rosbuild/ci_scripts/ws/install/urdfdom/lib/urdfdom/cmake/urdfdom-config.cmake:23 (find_package):
  By not providing "Findconsole_bridge.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "console_bridge", but CMake did not find one.

  Could not find a package configuration file provided by "console_bridge"
  with any of the following names:

    console_bridgeConfig.cmake
    console_bridge-config.cmake

  Add the installation prefix of "console_bridge" to CMAKE_PREFIX_PATH or set
  "console_bridge_DIR" to a directory containing one of the above files.  If
  "console_bridge" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  /home/rosbuild/ci_scripts/ws/install/urdf/share/urdf/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
  /home/rosbuild/ci_scripts/ws/install/urdf/share/urdf/cmake/urdfConfig.cmake:30 (include)
  CMakeLists.txt:9 (find_package)
```

The updated regex also catches warnings without a scope / category:

```
CMake Warning (dev) at cmake/environment_hooks/ament_generate_package_environment.cmake:52:
  uninitialized variable '_AMENT_CMAKE_ENVIRONMENT_HOOKS_bash'
This warning is for project developers.  Use -Wno-dev to suppress it.
```