### PR TITLE
Add a short message deprecating Trusty support for buildfarm deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+***Deprecation notice***
+
+This branch supports deployment to Ubuntu 14.04 (Trusty) hosts.
+The canonical buildfarm: [build.ros.org](https://build.ros.org) has migrated to Ubuntu 16.04 (Xenial) with a substantial refactoring of the puppet scripts.
+
+This Trusty branch will no longer receive improvements or bug fixes from Open Robotics but you're welcome to keep using it until you have the opportunity to migrate to Xenial.
+
 ## Overview
 
 For an overview about the ROS build farm including how to deploy the necessary


### PR DESCRIPTION
I've created a `trusty` branch based on the current master. This adds a deprecation notice to its README.

Along with this pull request itself, these are the only warnings we're giving community members about the changes we've made.

I think it might be a good idea to retarget #146 to a `xenial` branch and wait until we can announce the changes, and I have a little bit of time to distill the migration checklist I created for build.ros.org into main salient points for others before throwing their worlds into chaos when the reconfigure jobs pull a completely refactored set of puppet scripts.

What say you @tfoote?