### PR TITLE
improve CMake regex to detect messages without filename:linenumber

### DIFF
--- a/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
@@ -3,17 +3,23 @@
   <groovyParsers>
     <hudson.plugins.warnings.GroovyParser>
       <name>CMake</name>
-      <regexp>^CMake (Deprecation Warning|Warning|Warning \(dev\)|Error) at (.+):(\d+)( \((.+)\))?:\n(  .+\n)?(.+\n(  .+\n)*)?</regexp>
+      <regexp>^CMake (Deprecation Warning|Warning|Warning \(dev\)|Error)( at (.+):(\d+)( \((.+)\))?)?:\n(?!  Manually-specified variables were not used by the project:)(  .+\n)?(.+\n(  .+\n)*)?</regexp>
       <script>import hudson.plugins.analysis.util.model.Priority
 import hudson.plugins.warnings.parser.Warning
 
 String messageType = matcher.group(1)
-String fileName = matcher.group(2)
-String lineNumber = matcher.group(3)
-String scope = matcher.group(5)
-String cmakeMessage = matcher.group(6)
-String callStack = matcher.group(7)
+String fileName = matcher.group(3)
+String lineNumber = matcher.group(4)
+String scope = matcher.group(6)
+String cmakeMessage = matcher.group(7)
+String callStack = matcher.group(8)
 
+if (!fileName) {
+    fileName = &quot;no filename&quot;
+}
+if (!lineNumber) {
+    lineNumber = &quot;0&quot;;
+}
 if (!scope) {
     scope = &quot;global&quot;
 }


### PR DESCRIPTION
Addresses ros2/build_cop#73.

The following messages are being ignored since we currently pass some CMake variables to all packages even though they are only expected by some packages:

> Manually-specified variables were not used by the project: ...

The change has already been deployed on ci.ros2.org.