### PR TITLE
fixing newlines when generating squid-in-a-can service file

### DIFF
--- a/modules/profile/manifests/squidinacan.pp
+++ b/modules/profile/manifests/squidinacan.pp
@@ -20,15 +20,16 @@ class profile::squidinacan {
 
   $disk_cache_size = hiera('squid-in-a-can::max_cache_size', 5000)
   $max_cache_object = hiera('squid-in-a-can::max_cache_object', 1000)
+
   docker::run {'squid-in-a-can':
     image   => 'jpetazzo/squid-in-a-can',
     command => '/tmp/deploy_squid.py',
     env     => ["DISK_CACHE_SIZE=${disk_cache_size}",
                 "MAX_CACHE_OBJECT=${max_cache_object}",
-                'SQUID_DIRECTIVES=\'
-refresh_pattern . 0 0 1 refresh-ims
-refresh_all_ims on # make sure we do not get out of date content #41
-ignore_expect_100 on # needed for new relic system monitor
+                'SQUID_DIRECTIVES=\' \\
+refresh_pattern . 0 0 1 refresh-ims \
+refresh_all_ims on # make sure we do not get out of date content #41 \
+ignore_expect_100 on # needed for new relic system monitor \
 \''],
     volumes => ['/var/cache/squid-in-a-can:/var/cache/squid3',
                 '/var/log/squid-in-a-can:/var/log/squid3',


### PR DESCRIPTION
I was getting errors when trying to deploy the agent:

```
2018-01-10 12:30:13 +0100 Puppet (err): Could not start Service[docker-squid-in-a-can]: Execution of '/bin/systemctl start docker-squid-in-a-can' returned 1: Failed to start docker-squid-in-a-can.serv
See system logs and 'systemctl status docker-squid-in-a-can.service' for details.
2018-01-10 12:30:13 +0100 /Stage[main]/Profile::Squidinacan/Docker::Run[squid-in-a-can]/Service[docker-squid-in-a-can]/ensure (err): change from stopped to running failed: Could not start Service[dock
See system logs and 'systemctl status docker-squid-in-a-can.service' for details.
```

```
# systemctl status docker-squid-in-a-can.service
● docker-squid-in-a-can.service - Daemon for squid-in-a-can
   Loaded: error (Reason: Invalid argument)
   Active: inactive (dead)

ene 10 12:30:13 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:19] Unbalanced quoting, ignoring: "/usr/bin/docker run          --net host -m 0b -e DISK_CACHE_SIZE=50000 -e M
ene 10 12:30:13 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:20] Missing '='.
ene 10 12:32:21 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:19] Unbalanced quoting, ignoring: "/usr/bin/docker run          --net host -m 0b -e DISK_CACHE_SIZE=50000 -e M
ene 10 12:32:21 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:20] Missing '='.
ene 10 12:45:02 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:19] Unbalanced quoting, ignoring: "/usr/bin/docker run          --net host -m 0b -e DISK_CACHE_SIZE=50000 -e M
ene 10 12:45:02 xxxx systemd[1]: [/etc/systemd/system/docker-squid-in-a-can.service:20] Missing '='.
```
