### PR TITLE
Add missing dependencies to allow repo initialization on first puppet run.

### DIFF
--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -190,7 +190,8 @@ class profile::ros::repo {
         logoutput   => on_failure,
         require     => [
           Vcsrepo["/home/${agent_username}/reprepro-updater"],
-          File["/home/${agent_username}/.buildfarm/reprepro-updater.ini", $repo_dirs],
+          File["/home/${agent_username}/.buildfarm/reprepro-updater.ini"],
+          File['/var/repos', '/var/repos/ubuntu'],
           Class['python'],
           Package['python-yaml', 'python-configparser'],
         ]

--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -182,7 +182,7 @@ class profile::ros::repo {
     exec {'init_building_repo':
       path        => '/bin:/usr/bin',
       command     => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_building -c",
-      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src:\$PYTHONPATH"],
+      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src"],
       user  => $agent_username,
       group  => $agent_username,
       unless      => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_building -q",
@@ -196,7 +196,7 @@ class profile::ros::repo {
     exec {'init_testing_repo':
       path        => '/bin:/usr/bin',
       command     => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_testing -c",
-      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src:\$PYTHONPATH"],
+      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src"],
       user  => $agent_username,
       group  => $agent_username,
       unless      => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_testing -q",
@@ -210,7 +210,7 @@ class profile::ros::repo {
     exec {'init_main_repo':
       path        => '/bin:/usr/bin',
       command     => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_main -c",
-      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src:\$PYTHONPATH"],
+      environment => ["PYTHONPATH=/home/${agent_username}/reprepro-updater/src"],
       user  => $agent_username,
       group  => $agent_username,
       unless      => "/home/${agent_username}/reprepro-updater/scripts/setup_repo.py ubuntu_testing -q",

--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -190,7 +190,7 @@ class profile::ros::repo {
         logoutput   => on_failure,
         require     => [
           Vcsrepo["/home/${agent_username}/reprepro-updater"],
-          File["/home/${agent_username}/.buildfarm/reprepro-updater.ini"],
+          File["/home/${agent_username}/.buildfarm/reprepro-updater.ini", $repo_dirs],
           Class['python'],
           Package['python-yaml', 'python-configparser'],
         ]

--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -192,7 +192,7 @@ class profile::ros::repo {
           Vcsrepo["/home/${agent_username}/reprepro-updater"],
           File["/home/${agent_username}/.buildfarm/reprepro-updater.ini"],
           Class['python'],
-          Package['python-yaml'],
+          Package['python-yaml', 'python-configparser'],
         ]
       }
     }

--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -192,7 +192,6 @@ class profile::ros::repo {
           Vcsrepo["/home/${agent_username}/reprepro-updater"],
           File["/home/${agent_username}/.buildfarm/reprepro-updater.ini"],
           File['/var/repos', '/var/repos/ubuntu'],
-          Class['python'],
           Package['python-yaml', 'python-configparser'],
         ]
       }

--- a/modules/profile/manifests/ros/repo.pp
+++ b/modules/profile/manifests/ros/repo.pp
@@ -191,6 +191,7 @@ class profile::ros::repo {
         require     => [
           Vcsrepo["/home/${agent_username}/reprepro-updater"],
           File["/home/${agent_username}/.buildfarm/reprepro-updater.ini"],
+          Class['python'],
           Package['python-yaml'],
         ]
       }


### PR DESCRIPTION
Puppet, at least version 3.8.5, does not evaluate environment variable strings for variable expansion, which was leading to a PYTHONPATH variable of `/home/jenkins-agent/reprepro-updater/src:$PYTHONPATH` with a literal `$PYTHONPATH`.

This interfered with the default path and caused https://github.com/ros-infrastructure/buildfarm_deployment/issues/174

I made a test deployment with this patch (and a few others). @gavanderhoorn if you have time to verify that this addresses #174 for you it would be appreciated.

