### PR TITLE
Refresh apt after jenkins source added.

### DIFF
--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -3,6 +3,7 @@ class profile::jenkins::master {
   include ::jenkins::master
   include profile::jenkins::rosplugins
   include profile::jenkins::agent
+  Apt::Source['jenkins'] -> Class['Apt::Update'] -> Package<|tag == $::jenkins::package_name|>
 
   include jenkins_files
 

--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -3,6 +3,11 @@ class profile::jenkins::master {
   include ::jenkins::master
   include profile::jenkins::rosplugins
   include profile::jenkins::agent
+
+  # This is a workaround for https://github.com/jenkinsci/puppet-jenkins/pull/821
+  # Creates a dependency thread from adding the jenkins source repository, updating apt repos,
+  # and installing the Jenkins package.
+  # This can get removed when that PR merges and we update to a release that includes it.
   Apt::Source['jenkins'] -> Class['Apt::Update'] -> Package<|tag == $::jenkins::package_name|>
 
   include jenkins_files


### PR DESCRIPTION
Fixes #70 and also fixes #171.

There's an upstreamed solution for this at https://github.com/jenkinsci/puppet-jenkins/pull/821.

This should hold us for now.