### PR TITLE
Run docker image prune every night at midnight.

### DIFF
--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -270,4 +270,14 @@ class profile::jenkins::master {
     group => 'jenkins',
     content => template('jenkins_files/credentials.xml.erb'),
   }
+
+  cron {'docker image prune':
+    command => 'docker image prune -f'
+    user    => root,
+    month   => absent,
+    monthday => absent,
+    hour    => '0',
+    minute  => '0',
+    weekday => absent,
+  }
 }

--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -272,7 +272,7 @@ class profile::jenkins::master {
   }
 
   cron {'docker image prune':
-    command => 'docker image prune -f'
+    command => 'docker image prune -f',
     user    => root,
     month   => absent,
     monthday => absent,


### PR DESCRIPTION
As discovered today, the master host was doing nothing to clean up stale images and the sheer volume of them was affecting docker performance.

Pruning dangling images resolved the performance issues.

With this puppet change newly provisioned master hosts will prune dangling images every night at midnight. build.ros.org will require a manual update to the crontab in order to receive the same update because of #160 .