### PR TITLE
Reconcile plugins with production build.ros.org.

### DIFF
--- a/modules/profile/manifests/jenkins/rosplugins.pp
+++ b/modules/profile/manifests/jenkins/rosplugins.pp
@@ -1,10 +1,10 @@
-# This module was automatically generated on 2017-08-28 11:59:04
+# This module was automatically generated on 2018-03-21 10:16:50
 # Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.
 # Otherwise your changes will be overwritten the next time it is run.
 class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'PrioritySorter':
     version => '3.5.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['workflow-durable-task-step'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['matrix-project'] ]
   }
 
   ::jenkins::plugin { 'ace-editor':
@@ -30,11 +30,6 @@ class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'audit-trail':
     version => '2.2',
     require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['windows-slaves'] ]
-  }
-
-  ::jenkins::plugin { 'authentication-tokens':
-    version => '1.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'] ]
   }
 
   ::jenkins::plugin { 'bazaar':
@@ -77,11 +72,6 @@ class profile::jenkins::rosplugins {
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
   }
 
-  ::jenkins::plugin { 'credentials-binding':
-    version => '1.13',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-step-api'] ]
-  }
-
   ::jenkins::plugin { 'cvs':
     version => '2.13',
     require => [ Jenkins::Plugin['bouncycastle-api'] ]
@@ -105,16 +95,6 @@ class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'display-url-api':
     version => '2.0',
     require => [ Jenkins::Plugin['bouncycastle-api'] ]
-  }
-
-  ::jenkins::plugin { 'docker-commons':
-    version => '1.8',
-    require => [ Jenkins::Plugin['authentication-tokens'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['credentials-binding'], Jenkins::Plugin['icon-shim'] ]
-  }
-
-  ::jenkins::plugin { 'docker-workflow':
-    version => '1.12',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['docker-commons'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-durable-task-step'] ]
   }
 
   ::jenkins::plugin { 'durable-task':
@@ -157,11 +137,6 @@ class profile::jenkins::rosplugins {
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
   }
 
-  ::jenkins::plugin { 'git-server':
-    version => '1.7',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['git-client'] ]
-  }
-
   ::jenkins::plugin { 'github':
     version => '1.28.0',
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github-api'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['token-macro'] ]
@@ -195,11 +170,6 @@ class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'groovy-postbuild':
     version => '2.3.1',
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-cps'] ]
-  }
-
-  ::jenkins::plugin { 'handlebars':
-    version => '1.1.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
   }
 
   ::jenkins::plugin { 'icon-shim':
@@ -272,11 +242,6 @@ class profile::jenkins::rosplugins {
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
   }
 
-  ::jenkins::plugin { 'momentjs':
-    version => '1.1.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
-  }
-
   ::jenkins::plugin { 'monitoring':
     version => '1.69.0',
     require => [ Jenkins::Plugin['bouncycastle-api'] ]
@@ -290,66 +255,6 @@ class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'parameterized-trigger':
     version => '2.35.1',
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['conditional-buildstep'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['subversion'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-build-step':
-    version => '2.5.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-graph-analysis':
-    version => '1.5',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['pipeline-input-step'], Jenkins::Plugin['pipeline-stage-step'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-input-step':
-    version => '2.8',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-milestone-step':
-    version => '1.3.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-model-api':
-    version => '1.1.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-step-api'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-model-declarative-agent':
-    version => '1.1.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['pipeline-model-extensions'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-model-definition':
-    version => '1.1.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials-binding'], Jenkins::Plugin['docker-workflow'], Jenkins::Plugin['pipeline-model-api'], Jenkins::Plugin['pipeline-model-declarative-agent'], Jenkins::Plugin['pipeline-model-extensions'], Jenkins::Plugin['pipeline-stage-step'], Jenkins::Plugin['pipeline-stage-tags-metadata'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-basic-steps'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-cps-global-lib'], Jenkins::Plugin['workflow-durable-task-step'], Jenkins::Plugin['workflow-multibranch'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-support'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-model-extensions':
-    version => '1.1.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['pipeline-model-api'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-job'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-rest-api':
-    version => '2.8',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['pipeline-graph-analysis'], Jenkins::Plugin['pipeline-input-step'], Jenkins::Plugin['pipeline-stage-step'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-stage-step':
-    version => '2.2',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-stage-tags-metadata':
-    version => '1.1.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
-  }
-
-  ::jenkins::plugin { 'pipeline-stage-view':
-    version => '2.8',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['handlebars'], Jenkins::Plugin['jquery-detached'], Jenkins::Plugin['momentjs'], Jenkins::Plugin['pipeline-rest-api'], Jenkins::Plugin['workflow-job'] ]
   }
 
   ::jenkins::plugin { 'plain-credentials':
@@ -383,7 +288,7 @@ class profile::jenkins::rosplugins {
   }
 
   ::jenkins::plugin { 'script-security':
-    version => '1.33',
+    version => '1.34',
     require => [ Jenkins::Plugin['bouncycastle-api'] ]
   }
 
@@ -423,8 +328,8 @@ class profile::jenkins::rosplugins {
   }
 
   ::jenkins::plugin { 'token-macro':
-    version => '2.2',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-aggregator'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.3',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'translation':
@@ -442,39 +347,19 @@ class profile::jenkins::rosplugins {
     require => [ Jenkins::Plugin['bouncycastle-api'] ]
   }
 
-  ::jenkins::plugin { 'workflow-aggregator':
-    version => '2.5',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['pipeline-build-step'], Jenkins::Plugin['pipeline-input-step'], Jenkins::Plugin['pipeline-milestone-step'], Jenkins::Plugin['pipeline-model-definition'], Jenkins::Plugin['pipeline-stage-step'], Jenkins::Plugin['pipeline-stage-view'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-basic-steps'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-cps-global-lib'], Jenkins::Plugin['workflow-durable-task-step'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-multibranch'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
   ::jenkins::plugin { 'workflow-api':
     version => '2.20',
     require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
-  ::jenkins::plugin { 'workflow-basic-steps':
-    version => '2.6',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['mailer'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
-  }
-
   ::jenkins::plugin { 'workflow-cps':
-    version => '2.39',
+    version => '2.40',
     require => [ Jenkins::Plugin['ace-editor'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['jquery-detached'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
   }
 
-  ::jenkins::plugin { 'workflow-cps-global-lib':
-    version => '2.8',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['git-client'], Jenkins::Plugin['git-server'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-scm-step'] ]
-  }
-
-  ::jenkins::plugin { 'workflow-durable-task-step':
-    version => '2.14',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['durable-task'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
-  }
-
   ::jenkins::plugin { 'workflow-job':
-    version => '2.12.2',
-    require => [ Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
+    version => '2.11.2',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
   }
 
   ::jenkins::plugin { 'workflow-multibranch':

--- a/modules/profile/manifests/jenkins/rosplugins.pp
+++ b/modules/profile/manifests/jenkins/rosplugins.pp
@@ -1,4 +1,4 @@
-# This module was automatically generated on 2018-03-21 10:16:50
+# This module was automatically generated on 2018-03-21 13:38:39
 # Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.
 # Otherwise your changes will be overwritten the next time it is run.
 class profile::jenkins::rosplugins {
@@ -289,7 +289,7 @@ class profile::jenkins::rosplugins {
 
   ::jenkins::plugin { 'script-security':
     version => '1.34',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [  ]
   }
 
   ::jenkins::plugin { 'ssh-agent':


### PR DESCRIPTION
Synchronizes plugins to install with build.ros.org using plugin script.
### Removed plugins since sync:
* [authentication-tokens](https://plugins.jenkins.io/authentication-tokens)
* [credentials-binding](https://plugins.jenkins.io/credentials-binding)
* [docker-commons](https://plugins.jenkins.io/docker-commons)
* [docker-workflow](https://plugins.jenkins.io/docker-workflow)
* [git-server](https://plugins.jenkins.io/git-server)
* [handlebars](https://plugins.jenkins.io/handlebars)
* [momentjs](https://plugins.jenkins.io/momentjs)
* [pipeline-build-step](https://plugins.jenkins.io/pipeline-build-step)
* [pipeline-graph-analysis](https://plugins.jenkins.io/pipeline-graph-analysis)
* [pipeline-input-step](https://plugins.jenkins.io/pipeline-input-step)
* [pipeline-milestone-step](https://plugins.jenkins.io/pipeline-milestone-step)
* [pipeline-model-api](https://plugins.jenkins.io/pipeline-model-api)
* [pipeline-model-declarative-agent](https://plugins.jenkins.io/pipeline-model-declarative-agent)
* [pipeline-model-definition](https://plugins.jenkins.io/pipeline-model-definition)
* [pipeline-model-extensions](https://plugins.jenkins.io/pipeline-model-extensions)
* [pipeline-rest-api](https://plugins.jenkins.io/pipeline-rest-api)
* [pipeline-stage-step](https://plugins.jenkins.io/pipeline-stage-step)
* [pipeline-stage-tags-metadata](https://plugins.jenkins.io/pipeline-stage-tags-metadata)
* [pipeline-stage-view](https://plugins.jenkins.io/pipeline-stage-view)
* [workflow-aggregator](https://plugins.jenkins.io/workflow-aggregator)
* [workflow-basic-steps](https://plugins.jenkins.io/workflow-basic-steps)
* [workflow-cps-global-lib](https://plugins.jenkins.io/workflow-cps-global-lib)
* [workflow-durable-task-step](https://plugins.jenkins.io/workflow-durable-task-step)

### Updated plugins since sync
* [script-security](https://plugins.jenkins.io/script-security) 1.33 -> 1.34
* [token-macro](https://plugins.jenkins.io/token-macro) 2.2 -> 2.3
* [workflow-cps](https://plugins.jenkins.io/workflow-cps) 2.39 -> 2.40

### Downgraded plugins since sync
* [workflow-job](https://plugins.jenkins.io/workflow-job) 2.12.2 -> 2.11.2

### Other changes
* [PrioritySorter](https://plugins.jenkins.io/PrioritySorter) dependency change
* [token-macro](https://plugins.jenkins.io/token-macro) dependency change
* [workflow-job](https://plugins.jenkins.io/workflow-job) dependency change