### PR TITLE
Add a blank service override template.

### DIFF
--- a/modules/agent_files/templates/docker-service-overrides.conf.erb
+++ b/modules/agent_files/templates/docker-service-overrides.conf.erb
@@ -1,0 +1,6 @@
+# This file file should be empty of actual config overrides.  It exists because
+# the default overrides provded by garethr-docker are not suitable for 18.03+
+# on Xenial.
+#
+# In order to override the default overrides, a template must exist. It is not
+# enough (as near as I can tell) to set the override value to undef.


### PR DESCRIPTION
Current versions of Docker don't work with the overrides in place.
The service override template used by the puppet docker module no longer works when upgrading to docker 18.03. Setting the template to null or `undef` doesn't appear to be sufficient to override the default and not have a template. So we supply a blank one for now.

Needed for https://github.com/ros-infrastructure/buildfarm_deployment_config/pull/34