### PR TITLE
Update deployment to support post-JEP-200 Jenkins versions

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ mod 'puppetlabs-apache', '1.11.0'
 mod 'puppetlabs-concat', '2.2.0'
 mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
-mod 'jenkins', 
+mod 'voxpupuli-jenkins', 
   :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
   :ref => '1.7.0-rosbuildfarm0'
 mod 'stankevich/python', '1.18.2'

--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
 mod 'jenkins', 
   :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
-  :branch => '1.7.0-rosbuildfarm0'
+  :ref => '1.7.0-rosbuildfarm0'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"

--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,9 @@ mod 'puppetlabs-apache', '1.11.0'
 mod 'puppetlabs-concat', '2.2.0'
 mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
-mod 'rtyler/jenkins', '1.7.0'
+mod 'jenkins', 
+  :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
+  :branch => '1.7.0-rosbuildfarm0'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"

--- a/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.mercurial.MercurialInstallation.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.plugins.mercurial.MercurialInstallation_-DescriptorImpl plugin="mercurial@2.1">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.mercurial.MercurialInstallation_-DescriptorImpl plugin="mercurial@2.4">
   <installations>
     <hudson.plugins.mercurial.MercurialInstallation>
       <name>Default</name>

--- a/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/hudson.plugins.warnings.WarningsPublisher.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.plugins.warnings.WarningsDescriptor plugin="warnings@4.52">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.warnings.WarningsDescriptor plugin="warnings@4.68">
   <groovyParsers>
     <hudson.plugins.warnings.GroovyParser>
       <name>CMake</name>

--- a/modules/jenkins_files/files/var/lib/jenkins/hudson.scm.SubversionSCM.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/hudson.scm.SubversionSCM.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.scm.SubversionSCM_-DescriptorImpl plugin="subversion@2.5.7">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.scm.SubversionSCM_-DescriptorImpl plugin="subversion@2.12.1">
   <generation>1</generation>
   <mayHaveLegacyPerJobCredentials>false</mayHaveLegacyPerJobCredentials>
   <workspaceFormat>31</workspaceFormat>

--- a/modules/jenkins_files/files/var/lib/jenkins/jenkins.advancedqueue.PriorityConfiguration.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/jenkins.advancedqueue.PriorityConfiguration.xml
@@ -1,11 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<jenkins.advancedqueue.PriorityConfiguration plugin="PrioritySorter@3.4">
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.advancedqueue.PriorityConfiguration plugin="PrioritySorter@3.6.0">
   <jobGroups class="linked-list">
     <jenkins.advancedqueue.JobGroup>
       <id>0</id>
       <priority>-1</priority>
       <jobGroupStrategy class="jenkins.advancedqueue.jobinclusion.strategy.AllJobsJobInclusionStrategy"/>
-      <description>All</description>
+      <description></description>
       <runExclusive>false</runExclusive>
       <useJobFilter>false</useJobFilter>
       <jobPattern>.*</jobPattern>

--- a/modules/jenkins_files/files/var/lib/jenkins/jenkins.advancedqueue.PrioritySorterConfiguration.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/jenkins.advancedqueue.PrioritySorterConfiguration.xml
@@ -1,15 +1,8 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<jenkins.advancedqueue.PrioritySorterConfiguration plugin="PrioritySorter@3.4">
+<?xml version='1.1' encoding='UTF-8'?>
+<jenkins.advancedqueue.PrioritySorterConfiguration plugin="PrioritySorter@3.6.0">
   <allowPriorityOnJobs>false</allowPriorityOnJobs>
   <onlyAdminsMayEditPriorityConfiguration>true</onlyAdminsMayEditPriorityConfiguration>
   <strategy class="jenkins.advancedqueue.sorter.strategy.AbsoluteStrategy">
-    <ifCondition></ifCondition>
-    <unlessCondition></unlessCondition>
-    <children/>
-    <location>
-      <lineNumber>0</lineNumber>
-      <columnNumber>0</columnNumber>
-    </location>
     <numberOfPriorities>99</numberOfPriorities>
     <defaultPriority>99</defaultPriority>
   </strategy>

--- a/modules/jenkins_files/files/var/lib/jenkins/jobConfigHistory.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/jobConfigHistory.xml
@@ -1,9 +1,10 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.plugins.jobConfigHistory.JobConfigHistory plugin="jobConfigHistory@2.12">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.jobConfigHistory.JobConfigHistory plugin="jobConfigHistory@2.18.3">
   <historyRootDir></historyRootDir>
   <maxHistoryEntries></maxHistoryEntries>
   <maxEntriesPerPage></maxEntriesPerPage>
   <maxDaysToKeepEntries></maxDaysToKeepEntries>
+  <excludedUsers></excludedUsers>
   <skipDuplicateHistory>true</skipDuplicateHistory>
   <excludePattern>queue\.xml|nodeMonitors\.xml|UpdateCenter\.xml|global-build-stats</excludePattern>
   <saveModuleConfiguration>false</saveModuleConfiguration>

--- a/modules/jenkins_files/files/var/lib/jenkins/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote.xml
@@ -1,17 +1,19 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote_-DescriptorImpl plugin="collapsing-console-sections@1.4.1">
+<?xml version='1.1' encoding='UTF-8'?>
+<org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote_-DescriptorImpl plugin="collapsing-console-sections@1.7.0">
   <sections>
     <org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
       <sectionDisplayName>{1}</sectionDisplayName>
       <sectionStartPattern>^\# BEGIN SECTION: (.+)$</sectionStartPattern>
       <sectionEndPattern>^\# END SECTION$</sectionEndPattern>
       <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
+      <collapseSection>false</collapseSection>
     </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
     <org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
       <sectionDisplayName>{1}</sectionDisplayName>
       <sectionStartPattern>^\# BEGIN SUBSECTION: (.+)$</sectionStartPattern>
       <sectionEndPattern>^\# END SUBSECTION$</sectionEndPattern>
       <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
+      <collapseSection>false</collapseSection>
     </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
   </sections>
   <numberingEnabled>true</numberingEnabled>

--- a/modules/jenkins_files/files/var/lib/jenkins/scriptApproval.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/scriptApproval.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<scriptApproval plugin="script-security@1.34">
+<?xml version='1.1' encoding='UTF-8'?>
+<scriptApproval plugin="script-security@1.48">
   <approvedScriptHashes>
     <string>017d0db438428731cd600b6ebda805065433520f</string>
     <string>0494f61790c2498fd791726e7f80c2b4bf5667b2</string>
@@ -40,6 +40,8 @@
     <string>474bd1edd887204cf29d26933c648b6d6ca5f25f</string>
     <string>47eaea85b4cc7b98d4e5659cda316dc115ff18e6</string>
     <string>480d7bfe3a438d84bdb7fe651a433673a86a4c87</string>
+    <string>4817c7d417ff715180834f53c557bb1cfac72a9e</string>
+    <string>483032c6f144977b3f2038089f77d63c02f9f213</string>
     <string>4b840f0c38ac2cf4e9794df5769fe6a6debaf5b3</string>
     <string>55c8ca4db89a812ad8d81ae49fd8edf6757711a4</string>
     <string>55e514163f6853223b40c24a17d726f95b7f739e</string>
@@ -109,6 +111,7 @@
     <string>ce62ac4dab5b05f09dc94655d2a7efd73913e0e4</string>
     <string>cead0fc496cdee7e0b07188007156a0c47df4dfe</string>
     <string>cebd1305dba6437516c80810068fefe8fbf8ab65</string>
+    <string>cebf359f51d6f485a831074ecd81ec7659c95407</string>
     <string>cf7f7d5b0f5008bb41ca0935aec071753c4a7b37</string>
     <string>d070c19c21dabe933d4c94ca7d3788fa73b0afb2</string>
     <string>d27eeee179147948d370f2302aacb00defa564ae</string>
@@ -151,6 +154,7 @@
     <string>method hudson.model.BuildableItem scheduleBuild hudson.model.Cause</string>
     <string>method hudson.model.Item delete</string>
     <string>method hudson.model.Item getName</string>
+    <string>method hudson.model.ItemGroup getAllItems</string>
     <string>method hudson.model.Job getLastBuild</string>
     <string>method hudson.model.Job getNextBuildNumber</string>
     <string>method hudson.model.Job isBuilding</string>
@@ -174,6 +178,7 @@
     <string>method jenkins.model.Jenkins getItemByFullName java.lang.String</string>
     <string>method jenkins.model.Jenkins rebuildDependencyGraph</string>
     <string>method jenkins.model.ModifiableTopLevelItemGroup createProjectFromXML java.lang.String java.io.InputStream</string>
+    <string>method jenkins.model.ParameterizedJobMixIn$ParameterizedJob isDisabled</string>
     <string>method org.apache.xml.serialize.DOMSerializer serialize org.w3c.dom.Document</string>
     <string>method org.apache.xml.serialize.OutputFormat setIndent int</string>
     <string>method org.apache.xml.serialize.OutputFormat setIndenting boolean</string>

--- a/modules/profile/manifests/jenkins/rosplugins.pp
+++ b/modules/profile/manifests/jenkins/rosplugins.pp
@@ -1,4 +1,4 @@
-# This module was automatically generated on 2019-01-22 11:07:54
+# This module was automatically generated on 2019-01-22 11:09:04
 # Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.
 # Otherwise your changes will be overwritten the next time it is run.
 class profile::jenkins::rosplugins {

--- a/modules/profile/manifests/jenkins/rosplugins.pp
+++ b/modules/profile/manifests/jenkins/rosplugins.pp
@@ -1,400 +1,440 @@
-# This module was automatically generated on 2018-05-14 11:08:09
+# This module was automatically generated on 2019-01-22 11:07:54
 # Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.
 # Otherwise your changes will be overwritten the next time it is run.
 class profile::jenkins::rosplugins {
   ::jenkins::plugin { 'PrioritySorter':
-    version => '3.5.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['matrix-project'] ]
+    version => '3.6.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'] ]
   }
 
   ::jenkins::plugin { 'ace-editor':
     version => '1.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'analysis-core':
-    version => '1.92',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['dashboard-view'], Jenkins::Plugin['git'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
+    version => '1.95',
+    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['dashboard-view'], Jenkins::Plugin['git'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'ant':
-    version => '1.7',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['structs'] ]
+    version => '1.9',
+    require => [ Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'antisamy-markup-formatter':
     version => '1.5',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'] ]
+  }
+
+  ::jenkins::plugin { 'apache-httpcomponents-client-4-api':
+    version => '4.5.5-3.0',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'audit-trail':
-    version => '2.2',
-    require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['windows-slaves'] ]
+    version => '2.3',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
+  }
+
+  ::jenkins::plugin { 'badge':
+    version => '1.6',
+    require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'bazaar':
     version => '1.22',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
   }
 
   ::jenkins::plugin { 'bouncycastle-api':
-    version => '2.16.2',
-    require => [  ]
+    version => '2.17',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'branch-api':
-    version => '2.0.11',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'] ]
+    version => '2.0.20',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'build-timeout':
-    version => '1.18',
-    require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['windows-slaves'] ]
+    version => '1.19',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'cloudbees-folder':
-    version => '6.1.2',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'] ]
+    version => '6.6',
+    require => [ Jenkins::Plugin['credentials'] ]
   }
 
   ::jenkins::plugin { 'collapsing-console-sections':
-    version => '1.6.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.7.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jquery'] ]
+  }
+
+  ::jenkins::plugin { 'command-launcher':
+    version => '1.2',
+    require => [ Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['script-security'] ]
   }
 
   ::jenkins::plugin { 'conditional-buildstep':
     version => '1.3.6',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['run-condition'], Jenkins::Plugin['token-macro'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['run-condition'], Jenkins::Plugin['token-macro'] ]
+  }
+
+  ::jenkins::plugin { 'config-file-provider':
+    version => '3.4.1',
+    require => [ Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'copyartifact':
-    version => '1.38.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
+    version => '1.41',
+    require => [ Jenkins::Plugin['apache-httpcomponents-client-4-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'cvs':
-    version => '2.13',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '2.14',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jsch'] ]
   }
 
   ::jenkins::plugin { 'dashboard-view':
     version => '2.9.11',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
   }
 
   ::jenkins::plugin { 'description-setter':
     version => '1.10',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-project'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-project'] ]
   }
 
   ::jenkins::plugin { 'disable-failed-job':
     version => '1.15',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'display-url-api':
-    version => '2.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '2.2.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'durable-task':
-    version => '1.14',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.27',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'email-ext':
-    version => '2.58',
-    require => [ Jenkins::Plugin['analysis-core'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['script-security'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.63',
+    require => [ Jenkins::Plugin['analysis-core'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['config-file-provider'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'embeddable-build-status':
     version => '1.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'external-monitor-job':
     version => '1.7',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'extra-columns':
-    version => '1.18',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'] ]
+    version => '1.20',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['workflow-job'] ]
   }
 
   ::jenkins::plugin { 'ghprb':
-    version => '1.39.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['git'], Jenkins::Plugin['github'], Jenkins::Plugin['github-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['ssh-agent'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
+    version => '1.42.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['git'], Jenkins::Plugin['github'], Jenkins::Plugin['github-api'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'git':
-    version => '3.5.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['git-client'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['parameterized-trigger'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['workflow-scm-step'] ]
+    version => '3.9.1',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['git-client'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['parameterized-trigger'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'git-client':
-    version => '2.5.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
+    version => '2.7.3',
+    require => [ Jenkins::Plugin['apache-httpcomponents-client-4-api'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jsch'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'git-server':
     version => '1.7',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['git-client'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['git-client'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'github':
-    version => '1.28.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github-api'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['token-macro'] ]
+    version => '1.29.3',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github-api'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['plain-credentials'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'github-api':
-    version => '1.86',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['jackson2-api'] ]
+    version => '1.92',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jackson2-api'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'github-branch-source':
-    version => '2.2.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github'], Jenkins::Plugin['github-api'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'] ]
+    version => '2.4.1',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github'], Jenkins::Plugin['github-api'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'github-oauth':
-    version => '0.27',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['git'], Jenkins::Plugin['github-api'], Jenkins::Plugin['github-branch-source'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['workflow-multibranch'] ]
+    version => '0.29',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['git'], Jenkins::Plugin['github-api'], Jenkins::Plugin['github-branch-source'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['workflow-multibranch'] ]
   }
 
   ::jenkins::plugin { 'greenballs':
     version => '1.15',
-    require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+    require => [ Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
   }
 
   ::jenkins::plugin { 'groovy':
     version => '2.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['token-macro'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['script-security'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'groovy-postbuild':
-    version => '2.3.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-cps'] ]
+    version => '2.4.2',
+    require => [ Jenkins::Plugin['badge'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['workflow-cps'] ]
   }
 
   ::jenkins::plugin { 'icon-shim':
     version => '2.0.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'jackson2-api':
-    version => '2.7.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '2.9.7.1',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'javadoc':
     version => '1.4',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
+  }
+
+  ::jenkins::plugin { 'jdk-tool':
+    version => '1.1',
+    require => [  ]
   }
 
   ::jenkins::plugin { 'jobConfigHistory':
-    version => '2.17',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
+    version => '2.18.3',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'] ]
   }
 
   ::jenkins::plugin { 'jobrequeue':
     version => '1.1',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+  }
+
+  ::jenkins::plugin { 'jquery':
+    version => '1.12.4-0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'jquery-detached':
     version => '1.2.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
+  }
+
+  ::jenkins::plugin { 'jsch':
+    version => '0.1.54.2',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['ssh-credentials'] ]
   }
 
   ::jenkins::plugin { 'junit':
-    version => '1.21',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['structs'] ]
+    version => '1.26.1',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'ldap':
-    version => '1.16',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['mailer'] ]
+    version => '1.20',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['mailer'] ]
   }
 
   ::jenkins::plugin { 'mailer':
-    version => '1.20',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['display-url-api'] ]
+    version => '1.22',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['display-url-api'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'mapdb-api':
     version => '1.0.9.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'] ]
   }
 
   ::jenkins::plugin { 'matrix-auth':
-    version => '1.7',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['icon-shim'] ]
+    version => '2.3',
+    require => [ Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'matrix-project':
-    version => '1.11',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'], Jenkins::Plugin['script-security'] ]
+    version => '1.13',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['script-security'] ]
   }
 
   ::jenkins::plugin { 'maven-plugin':
-    version => '2.17',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['mailer'], Jenkins::Plugin['token-macro'] ]
+    version => '3.1.2',
+    require => [ Jenkins::Plugin['apache-httpcomponents-client-4-api'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jsch'], Jenkins::Plugin['junit'], Jenkins::Plugin['mailer'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'mercurial':
-    version => '2.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
+    version => '2.4',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jsch'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'monitoring':
-    version => '1.69.0',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.74.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'pam-auth':
-    version => '1.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'] ]
+    version => '1.4',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'] ]
   }
 
   ::jenkins::plugin { 'parameterized-trigger':
-    version => '2.35.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['conditional-buildstep'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['subversion'] ]
+    version => '2.35.2',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['conditional-buildstep'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['script-security'], Jenkins::Plugin['subversion'] ]
   }
 
   ::jenkins::plugin { 'plain-credentials':
     version => '1.4',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'pollscm':
     version => '1.3.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
+  }
+
+  ::jenkins::plugin { 'publish-over':
+    version => '0.22',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'publish-over-ssh':
-    version => '1.17',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.20.1',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['jsch'], Jenkins::Plugin['publish-over'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'purge-build-queue-plugin':
     version => '1.0',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
   }
 
   ::jenkins::plugin { 'run-condition':
-    version => '1.0',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['token-macro'], Jenkins::Plugin['windows-slaves'] ]
+    version => '1.2',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'scm-api':
-    version => '2.2.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['structs'] ]
+    version => '2.3.0',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'script-security':
-    version => '1.34',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.48',
+    require => [ Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'ssh-agent':
-    version => '1.15',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '1.17',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'ssh-credentials':
-    version => '1.13',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'] ]
+    version => '1.14',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'ssh-slaves':
-    version => '1.21',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['ssh-credentials'] ]
+    version => '1.28.1',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['ssh-credentials'] ]
   }
 
   ::jenkins::plugin { 'structs':
-    version => '1.10',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.17',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'subversion':
-    version => '2.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['credentials'], Jenkins::Plugin['mapdb-api'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['workflow-scm-step'] ]
+    version => '2.12.1',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['mapdb-api'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['ssh-credentials'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-scm-step'] ]
   }
 
   ::jenkins::plugin { 'systemloadaverage-monitor':
     version => '1.2',
-    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
+    require => [ Jenkins::Plugin['ant'], Jenkins::Plugin['antisamy-markup-formatter'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['external-monitor-job'], Jenkins::Plugin['javadoc'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['ldap'], Jenkins::Plugin['mailer'], Jenkins::Plugin['matrix-auth'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['pam-auth'], Jenkins::Plugin['windows-slaves'] ]
   }
 
   ::jenkins::plugin { 'timestamper':
-    version => '1.8.8',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '1.8.10',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'token-macro':
-    version => '2.3',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.5',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'translation':
-    version => '1.15',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    version => '1.16',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'warnings':
-    version => '4.63',
-    require => [ Jenkins::Plugin['analysis-core'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['dashboard-view'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['token-macro'] ]
+    version => '4.68',
+    require => [ Jenkins::Plugin['analysis-core'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['dashboard-view'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['matrix-project'], Jenkins::Plugin['maven-plugin'], Jenkins::Plugin['token-macro'] ]
   }
 
   ::jenkins::plugin { 'windows-slaves':
     version => '1.3.1',
-    require => [ Jenkins::Plugin['bouncycastle-api'] ]
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 
   ::jenkins::plugin { 'workflow-api':
-    version => '2.20',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.31',
+    require => [ Jenkins::Plugin['scm-api'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'workflow-cps':
-    version => '2.40',
-    require => [ Jenkins::Plugin['ace-editor'], Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['jquery-detached'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
+    version => '2.60',
+    require => [ Jenkins::Plugin['ace-editor'], Jenkins::Plugin['jquery-detached'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
   }
 
   ::jenkins::plugin { 'workflow-cps-global-lib':
-    version => '2.9',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['git-client'], Jenkins::Plugin['git-server'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-scm-step'] ]
+    version => '2.12',
+    require => [ Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['credentials'], Jenkins::Plugin['git-client'], Jenkins::Plugin['git-server'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-scm-step'] ]
   }
 
   ::jenkins::plugin { 'workflow-job':
-    version => '2.11.2',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
+    version => '2.28',
+    require => [ Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
   }
 
   ::jenkins::plugin { 'workflow-multibranch':
-    version => '2.16',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['branch-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
+    version => '2.20',
+    require => [ Jenkins::Plugin['branch-api'], Jenkins::Plugin['cloudbees-folder'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['structs'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-cps'], Jenkins::Plugin['workflow-job'], Jenkins::Plugin['workflow-scm-step'], Jenkins::Plugin['workflow-step-api'], Jenkins::Plugin['workflow-support'] ]
   }
 
   ::jenkins::plugin { 'workflow-scm-step':
-    version => '2.6',
-    require => [ Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.7',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'workflow-step-api':
-    version => '2.12',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['structs'] ]
+    version => '2.16',
+    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['structs'] ]
   }
 
   ::jenkins::plugin { 'workflow-support':
-    version => '2.14',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
+    version => '2.22',
+    require => [ Jenkins::Plugin['scm-api'], Jenkins::Plugin['script-security'], Jenkins::Plugin['workflow-api'], Jenkins::Plugin['workflow-step-api'] ]
   }
 
   ::jenkins::plugin { 'xunit':
-    version => '1.102',
-    require => [ Jenkins::Plugin['bouncycastle-api'], Jenkins::Plugin['junit'] ]
+    version => '2.3.1',
+    require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'], Jenkins::Plugin['junit'], Jenkins::Plugin['structs'] ]
   }
 
 }

--- a/scripts/jenkins_plugins.py
+++ b/scripts/jenkins_plugins.py
@@ -7,6 +7,7 @@ import sys
 
 from argparse import ArgumentParser
 from base64 import b64encode
+from collections import deque
 from datetime import datetime
 from urllib.request import Request, urlopen
 
@@ -26,20 +27,23 @@ def main():
     parser.add_argument("--password")
     parser.add_argument("--jenkins")
     args = parser.parse_args(sys.argv[1:])
-    generate_class(args)
+    data = fetch_data(args)
+    generate_class(data['plugins'])
 
-
-def generate_class(args):
-    print("# This module was automatically generated on {0:%Y-%m-%d %H:%M:%S}".format(datetime.now()))
-    print("# Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.")
-    print("# Otherwise your changes will be overwritten the next time it is run.")
-    print("class profile::jenkins::rosplugins {")
+def fetch_data(args):
     ciurl = "http://{}/pluginManager/api/json?depth=5".format(args.jenkins)
     plugin_request = Request(ciurl)
     plugin_request.add_header("Authorization", authorization_header_for(args.username, args.password))
     response = urlopen(plugin_request)
-    parsed = json.loads(response.read().decode())
-    for plugin in sorted(parsed['plugins'], key=lambda p: p['shortName']):
+    data = json.loads(response.read().decode())
+    return data
+
+def generate_class(plugins):
+    print("# This module was automatically generated on {0:%Y-%m-%d %H:%M:%S}".format(datetime.now()))
+    print("# Instead of editing it, update plugins via the Jenkins web UI and rerun the generator.")
+    print("# Otherwise your changes will be overwritten the next time it is run.")
+    print("class profile::jenkins::rosplugins {")
+    for plugin in sorted(plugins, key=lambda p: p['shortName']):
         if plugin['shortName'] in skip_plugins:
             continue
         dependencies = ", ".join(["Jenkins::Plugin['{}']".format(dep['shortName'])
@@ -47,6 +51,34 @@ def generate_class(args):
         print(resource_template.format(name=plugin['shortName'], version=plugin['version'],
                                        dependency_list="[ " + dependencies + " ]"))
     print("}")
+
+def generate_plugin_url_list(plugins):
+    """
+    Print out a CLI script for updating these plugins with the jenkins CLI.
+    I'm not fully in love with this yet so a small code change is required to use it.
+    """
+
+    plugin_dict = dict((p['shortName'], p) for p in plugins)
+    # Make a tiny depth-first processing queue to add layered dependencies
+    processed = set()
+    queue = deque(p['shortName'] for p in plugins)
+    while queue:
+        plugin_name = queue.pop()
+        if plugin_name in processed:
+            continue
+        plugin = plugin_dict[plugin_name]
+        needs_deps = False
+        for dep in plugin['dependencies']:
+            if dep['shortName'] not in processed:
+                needs_deps = True
+                break
+        if needs_deps:
+            queue.appendleft(plugin_name)
+            continue
+        url = "https://updates.jenkins.io/download/plugins/{plugin}/{version}/{plugin}.hpi".format(
+                plugin=plugin_name, version=plugin['version'])
+        processed.add(plugin_name)
+        print(url)
 
 
 def authorization_header_for(username, password):


### PR DESCRIPTION
The changes here seek to resolve issues with current Jenkins LTS.

PRs to [buildfarm_deployment_config](https://github.com/ros-infrastructure/buildfarm_deployment_config) and [ros_buildfarm](https://github.com/ros-infrastructure/ros_buildfarm) are on the way once things settle down. It's important to note that #160 is still outstanding and will not be resolved by this PR. Manual changes to existing buildfarms for people who want to upgrade will get drafted here. When we migrate build.ros2.org and build.ros.org I'll make a discord announcement as well but if anyone wants to try the "pre-release" state of the instructions watch this space and I'll of course be grateful for the feedback.

While I originally started trying to update plugins minimally it quickly became overwhelming so I've moved to a strategy of update everything and check what breaks.

Summary of updates:

* Forked upstream puppet-jenkins module to cherry pick changes we need for the newer swarm client plugin versions (Which themselves were needed to move off the deprecated JNLP version)
* Update plugin versions to latest available.
* Update of scriptApproval.xml with some additional signatures
* Write a script that jenkins admins can run to sync with the plugin versions in rosplugins.pp without re-running puppet.