### PR TITLE
Force completion of the setup wizard via Groovy script.

### DIFF
--- a/modules/profile/files/jenkins/master/complete_setup.groovy
+++ b/modules/profile/files/jenkins/master/complete_setup.groovy
@@ -1,0 +1,8 @@
+/* Configure Git User */
+
+/* This script is designed to be run via jenkins-cli.jar in order to update the
+ * configuration for the Jenkins GitSCM plugin.
+ */
+import jenkins.model.Jenkins
+
+jenkins.model.Jenkins.getInstance().getSetupWizard().completeSetup()

--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -27,7 +27,7 @@ class profile::jenkins::master {
     source => 'puppet:///modules/profile/jenkins/master/complete_setup.groovy',
   } ->
   rosjenkins::groovy { '/tmp/complete_setup.groovy':
-    require =>  Service['Jenkins'],
+    require =>  Service['jenkins'],
   }
 
 

--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -22,6 +22,15 @@ class profile::jenkins::master {
     require => Jenkins::Plugin['git'],
   }
 
+  # Complete the setup wizard so it is not shown on login.
+  file { '/tmp/complete_setup.groovy':
+    source => 'puppet:///modules/profile/jenkins/master/complete_setup.groovy',
+  } ->
+  rosjenkins::groovy { '/tmp/complete_setup.groovy':
+    require =>  Service['Jenkins'],
+  }
+
+
   # config for audit-trail
   file { '/var/lib/jenkins/audit-trail.xml':
     mode => '0640',


### PR DESCRIPTION
While investigating this I found [JENKINS-40279](https://issues.jenkins-ci.org/browse/JENKINS-40279) which I think is related.

I would like to try my hand at running Jenkins from source with a debugger attached and see if I can reproduce the issue and propose a fix. But that's a very lofty goal for a fellow with my outstanding commitments.

An alternative to these run-once Groovy scripts is to start making use of the `$JENKINS_HOME/init.groovy.d` directory. Into which Groovy scripts can be placed and they'll be run on Jenkins startup. But our Jenkins startup time is already measured in minutes due to the number of pull request hooks that get checked so if I can keep these run-once that works better for me.