### PR TITLE
Fix 'master' proxy vhost config (avoid: "proxy setup broken")

### DIFF
--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -220,6 +220,7 @@ class profile::jenkins::master {
   }
 
   apache::vhost { 'master':
+    allow_encoded_slashes => 'nodecode',
     docroot => '/var/www.html',
     port    => '80',
     proxy_pass => [

--- a/modules/profile/manifests/jenkins/master.pp
+++ b/modules/profile/manifests/jenkins/master.pp
@@ -223,7 +223,7 @@ class profile::jenkins::master {
     docroot => '/var/www.html',
     port    => '80',
     proxy_pass => [
-      { 'path' => '/', 'url' => 'http://localhost:8080/'},
+      { 'path' => '/', 'url' => 'http://localhost:8080/', 'keywords' => ['nocanon'] },
     ],
   }
 


### PR DESCRIPTION
This is for #212.

These were the minimum changes I had to make to the `master` proxy vhost configuration to make Jenkins happy about the proxy config of the master host.

Based on the puppet docs about [apache: Configuring virtual hosts](https://forge.puppet.com/puppetlabs/apache#configuring-virtual-hosts).
