### PR TITLE
add sections for colcon package output

### DIFF
--- a/modules/jenkins_files/files/var/lib/jenkins/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote.xml
+++ b/modules/jenkins_files/files/var/lib/jenkins/org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote.xml
@@ -15,6 +15,27 @@
       <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
       <collapseSection>false</collapseSection>
     </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+    <org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+      <sectionDisplayName>{1}</sectionDisplayName>
+      <sectionStartPattern>^Starting >>> (.+)$</sectionStartPattern>
+      <sectionEndPattern>.*</sectionEndPattern>
+      <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
+      <collapseSection>false</collapseSection>
+    </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+    <org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+      <sectionDisplayName>{1} (output)</sectionDisplayName>
+      <sectionStartPattern>^--- output: (.+)$</sectionStartPattern>
+      <sectionEndPattern>^---$</sectionEndPattern>
+      <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
+      <collapseSection>false</collapseSection>
+    </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+    <org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
+      <sectionDisplayName>{1} (stderr)</sectionDisplayName>
+      <sectionStartPattern>^--- stderr: (.+)$</sectionStartPattern>
+      <sectionEndPattern>^---$</sectionEndPattern>
+      <collapseOnlyOneLevel>false</collapseOnlyOneLevel>
+      <collapseSection>false</collapseSection>
+    </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote>
   </sections>
   <numberingEnabled>true</numberingEnabled>
 </org.jvnet.hudson.plugins.collapsingconsolesections.CollapsingSectionNote_-DescriptorImpl>


### PR DESCRIPTION
Adds three sections for colcon specific output as it is already in use on ci.ros2.org:

* Starting of a package build / test
* Output of a processed package
* Stderr output of a processed package