### PR TITLE
make sure the trace directory exists before dropping the timesta…

### DIFF
--- a/modules/profile/files/ros/repo/upload_repo.bash
+++ b/modules/profile/files/ros/repo/upload_repo.bash
@@ -14,6 +14,7 @@ case "$1" in
 		exit 1
 esac
 
+mkdir -p /var/repos/ubuntu/$repo/project/trace/
 date -u > /var/repos/ubuntu/$repo/project/trace/repositories.ros.org
 ssh -T -i $HOME/upload_triggers/$key ftpsync@ftp-osl.osuosl.org
 exit_code=$?


### PR DESCRIPTION
Otherwise it fails until you manually create the directory.