### PR TITLE
Fix plugins loading due to outdated structs plugin

### DIFF
--- a/modules/profile/manifests/jenkins/rosplugins.pp
+++ b/modules/profile/manifests/jenkins/rosplugins.pp
@@ -353,7 +353,7 @@ class profile::jenkins::rosplugins {
   }
 
   ::jenkins::plugin { 'structs':
-    version => '1.17',
+    version => '1.20',
     require => [ Jenkins::Plugin['command-launcher'], Jenkins::Plugin['jdk-tool'] ]
   }
 


### PR DESCRIPTION
I tried to install the buildfarm master on a fresh 16.04 host. Jenkins would not load due to an outdated structs plugin. After bumping the version all the other plugins started working.

I'm using the same Jenkins version as http://build.ros.org: 2.190.1