### PR TITLE
Use an updated puppet-jenkins module.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
 mod 'voxpupuli-jenkins', 
   :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
-  :ref => '1.7.0-rosbuildfarm0'
+  :ref => '1.7.0-rosbuildfarm1'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"


### PR DESCRIPTION
This bumps the forked jenkins module to include a patch I've just done
for a change in where the jenkins-cli jar is stored within recent
warfiles.

I haven't checked how far back this location is present for but with
issue #160 outstanding older versions of Jenkins won't ever get this
change. This is tested with only Jenkins 2.222.3

The patch in question is [this commit](https://github.com/nuclearsandwich/puppet-jenkins/commit/90f25c2287f792a321a4f7e1f8e3a5444652eef6).