### PR TITLE
Replace c3.large with c5.large

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ They are intended as a guideline for choosing the appropriate parameters when de
 
 <table>
 <tr><td>Disk space</td><td>200Gb+</td></tr>
-<tr><td><strong>Recommendation</strong></td><td>c3.large or faster</td></tr>
+<tr><td><strong>Recommendation</strong></td><td>c5.large or faster</td></tr>
 </table>
 
 ### Repo


### PR DESCRIPTION
c3 has been deprecated. These longer exists in us-east-1. c5 has been rolled out to more locations and should have more longevity:
https://aws.amazon.com/about-aws/whats-new/2019/08/amazon-ec2-c5-new-instance-sizes-are-now-available-in-additional-regions/

CPU/RAM were 2/3.75 GB for C3 and are 2/4GB for C5.
https://aws.amazon.com/ec2/previous-generation/
https://aws.amazon.com/blogs/aws/now-available-compute-intensive-c5-instances-for-amazon-ec2/