### PR TITLE
Adjust docker image cleanup tolerances.

### DIFF
--- a/modules/profile/manifests/jenkins/agent.pp
+++ b/modules/profile/manifests/jenkins/agent.pp
@@ -132,7 +132,7 @@ class profile::jenkins::agent (
 
   # clean up containers and dangling images https://github.com/docker/docker/issues/928#issuecomment-58619854
   cron {'docker_cleanup_images':
-    command => "bash -c \"python3 -u /home/${agent_username}/cleanup_docker_images.py --minimum-free-percent 10 --minimum-free-space 50\"",
+    command => "bash -c \"python3 -u /home/${agent_username}/cleanup_docker_images.py --minimum-free-percent 30 --minimum-free-space 60\"",
     user    => $agent_username,
     month   => absent,
     monthday => absent,


### PR DESCRIPTION
Jenkins and the cleanup script do their accounting slightly differently
so there are times when the cleanup script runs and Jenkins still
considers the disk to be too full.
By bumping the cleanup minimum to 60G that gives us a pretty comfortable
margin over the 50G minimum for Jenkins. I also bumped the percentage so
we don't flap on and off as frequently.

These changes affect all agents but I don't think any of them are harmed
by the tuning of these parameters.

As we work on the future agents we're going to delegate cleanup
responsibility to docker prune commands, which we are already doing for
the Jenkins host which previously did not have a configured cleanup
script.