### PR TITLE
Use a newer version of the Jenkins module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
 mod 'voxpupuli-jenkins', 
   :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
-  :ref => '1.7.0-rosbuildfarm1'
+  :ref => '1.7.0-rosbuildfarm2'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"

--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'puppetlabs-ntp', '4.2.0'
 mod 'puppetlabs-vcsrepo', '1.5.0'
 mod 'voxpupuli-jenkins', 
   :git => 'https://github.com/nuclearsandwich/puppet-jenkins',
-  :ref => '1.7.0-rosbuildfarm2'
+  :ref => '1.7.0-rosbuildfarm3'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
   :git => "git://github.com/newrelic/puppet-nrsysmond.git"


### PR DESCRIPTION
The latest fix in this branch is required for `buildfarm_deployment` to work right now.

https://github.com/nuclearsandwich/puppet-jenkins/tree/1.7.0-rosbuildfarm2