### PR TITLE
Support docker::registry_mirror config option.

### DIFF
--- a/modules/agent_files/files/docker-daemon.json
+++ b/modules/agent_files/files/docker-daemon.json
@@ -1,3 +1,0 @@
-{
-	"seccomp-profile": "/etc/docker/seccomp-profiles/docker-default-with-personality.json"
-}

--- a/modules/agent_files/templates/docker-daemon.json.erb
+++ b/modules/agent_files/templates/docker-daemon.json.erb
@@ -1,0 +1,4 @@
+{
+<% if ! scope.function_hiera(["docker::registry_mirror"], "").empty? %> "registry-mirrors": ["<%= scope.function_hiera(["docker::registry_mirror"])%>"],<% end -%>
+	"seccomp-profile": "/etc/docker/seccomp-profiles/docker-default-with-personality.json"
+}

--- a/modules/profile/manifests/jenkins/agent.pp
+++ b/modules/profile/manifests/jenkins/agent.pp
@@ -110,7 +110,7 @@ class profile::jenkins::agent (
   }
 
   file { '/etc/docker/daemon.json':
-    source  => 'puppet:///modules/agent_files/docker-daemon.json',
+    source  => template('agent_files/docker-daemon.json'),
     require => Class[docker],
   }
 


### PR DESCRIPTION
With Docker Hub's new rate limits[1] most buildfarm configurations will hit
the rate limit during normal operation. This would allow you to specify
a registry mirror to pull from. One recommendded configuration would be
to follow Docker's recipe for a read-through caching mirror[2].

To enable this new option add a hiera config field of
`docker::registry_mirror` to your common.yaml hiera configuration in
buildfarm_deployment_config.

:construction: 
Note for reviewers: I haven't tested this yet. The canonical buildfarms had their changes manually deployed as a proof-of-concept. If anyone does try this out and find it working I would love to hear about it.

[1]: https://www.docker.com/increase-rate-limits
[2]: https://docs.docker.com/registry/recipes/mirror/