### PR TITLE
Update puppet-nrsysmond url

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,6 @@ mod 'voxpupuli-jenkins',
   :ref => '1.7.0-rosbuildfarm3'
 mod 'stankevich/python', '1.18.2'
 mod 'newrelic-nrsysmond',
-  :git => "git://github.com/newrelic/puppet-nrsysmond.git"
+  :git => "https://github.com/newrelic/puppet-nrsysmond.git"
 
 mod 'saz-timezone', '3.4.0'


### PR DESCRIPTION
GitHub has disabled unencrypted git protocol, leading to errors during deployment. This fixes the problem.